### PR TITLE
Enable fixed vertices in C interface

### DIFF
--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -47,6 +47,7 @@ extern "C" {
 
 struct kahypar_context_s;
 typedef struct kahypar_context_s kahypar_context_t;
+typedef struct kahypar_hypergraph_s kahypar_hypergraph_t;
 
 typedef unsigned int kahypar_hypernode_id_t;
 typedef unsigned int kahypar_hyperedge_id_t;
@@ -59,9 +60,44 @@ KAHYPAR_API void kahypar_context_free(kahypar_context_t* kahypar_context);
 KAHYPAR_API void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                                      const char* ini_file_name);
 
+KAHYPAR_API void kahypar_hypergraph_free(kahypar_hypergraph_t* hypergraph);
+
 KAHYPAR_API void kahypar_set_custom_target_block_weights(const kahypar_partition_id_t num_blocks,
                                                          const kahypar_hypernode_weight_t* block_weights,
                                                          kahypar_context_t* kahypar_context);
+
+KAHYPAR_API void kahypar_set_fixed_vertices(kahypar_hypergraph_t* hypergraph,
+                                            const kahypar_partition_id_t* fixed_vertex_blocks);
+
+KAHYPAR_API kahypar_hypergraph_t* kahypar_create_hypergraph_from_file(const char* file_name,
+                                                                      const kahypar_partition_id_t num_blocks);
+
+KAHYPAR_API kahypar_hypergraph_t* kahypar_create_hypergraph(const kahypar_partition_id_t num_blocks,
+                                                            const kahypar_hypernode_id_t num_vertices,
+                                                            const kahypar_hyperedge_id_t num_hyperedges,
+                                                            const size_t* hyperedge_indices,
+                                                            const kahypar_hyperedge_id_t* hyperedges,
+                                                            const kahypar_hyperedge_weight_t* hyperedge_weights,
+                                                            const kahypar_hypernode_weight_t* vertex_weights);
+
+KAHYPAR_API void kahypar_partition_hypergraph(kahypar_hypergraph_t* kahypar_hypergraph,
+                                              const kahypar_partition_id_t num_blocks,
+                                              const double epsilon,
+                                              kahypar_hyperedge_weight_t* objective,
+                                              kahypar_context_t* kahypar_context,
+                                              kahypar_partition_id_t* partition);
+
+KAHYPAR_API void kahypar_improve_hypergraph_partition(kahypar_hypergraph_t* kahypar_hypergraph,
+                                                      const kahypar_partition_id_t num_blocks,
+                                                      const double epsilon,
+                                                      kahypar_hyperedge_weight_t* objective,
+                                                      kahypar_context_t* kahypar_context,
+                                                      const kahypar_partition_id_t* input_partition,
+                                                      const size_t num_improvement_iterations,
+                                                      kahypar_partition_id_t* improved_partition);
+
+
+KAHYPAR_API void kahypar_hypergraph_free(kahypar_hypergraph_t* kahypar_hypergraph);
 
 KAHYPAR_API void kahypar_read_hypergraph_from_file(const char* file_name,
                                                    kahypar_hypernode_id_t* num_vertices,

--- a/lib/libkahypar.cc
+++ b/lib/libkahypar.cc
@@ -52,11 +52,135 @@ void kahypar_context_free(kahypar_context_t* kahypar_context) {
   delete reinterpret_cast<kahypar::Context*>(kahypar_context);
 }
 
+void kahypar_hypergraph_free(kahypar_hypergraph_t* kahypar_hypergraph) {
+  if (kahypar_hypergraph == nullptr) {
+    return;
+  }
+  delete reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);
+}
+
 
 void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                          const char* ini_file_name) {
   kahypar::parseIniToContext(*reinterpret_cast<kahypar::Context*>(kahypar_context),
                              ini_file_name);
+}
+
+void kahypar_set_fixed_vertices(kahypar_hypergraph_t* kahypar_hypergraph,
+                                const kahypar_partition_id_t* fixed_vertex_blocks) {
+  kahypar::Hypergraph& hypergraph = *reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);
+  for (const auto hn : hypergraph.nodes()) {
+    if (fixed_vertex_blocks[hn] != -1) {
+      hypergraph.setFixedVertex(hn, fixed_vertex_blocks[hn]);
+    }
+  }
+}
+
+kahypar_hypergraph_t* kahypar_create_hypergraph_from_file(const char* file_name, const kahypar_partition_id_t num_blocks) {
+  kahypar::HypernodeID num_hypernodes;
+  kahypar::HyperedgeID num_hyperedges;
+  kahypar::HyperedgeIndexVector index_vector;
+  kahypar::HyperedgeVector edge_vector;
+  kahypar::HypernodeWeightVector hypernode_weights;
+  kahypar::HyperedgeWeightVector hyperedge_weights;
+  kahypar::io::readHypergraphFile(file_name, num_hypernodes, num_hyperedges,
+                                  index_vector, edge_vector, &hyperedge_weights, &hypernode_weights);
+  return reinterpret_cast<kahypar_hypergraph_t*>(new kahypar::Hypergraph(num_hypernodes, num_hyperedges, index_vector, edge_vector,
+                                                                         num_blocks, &hyperedge_weights, &hypernode_weights));
+}
+
+KAHYPAR_API kahypar_hypergraph_t* kahypar_create_hypergraph(const kahypar_partition_id_t num_blocks,
+                                                            const kahypar_hypernode_id_t num_vertices,
+                                                            const kahypar_hyperedge_id_t num_hyperedges,
+                                                            const size_t* hyperedge_indices,
+                                                            const kahypar_hyperedge_id_t* hyperedges,
+                                                            const kahypar_hyperedge_weight_t* hyperedge_weights,
+                                                            const kahypar_hypernode_weight_t* vertex_weights) {
+  return reinterpret_cast<kahypar_hypergraph_t*>(new kahypar::Hypergraph(num_vertices,
+                                                                         num_hyperedges,
+                                                                         hyperedge_indices,
+                                                                         hyperedges,
+                                                                         num_blocks,
+                                                                         hyperedge_weights,
+                                                                         vertex_weights));
+}
+
+void kahypar_partition_hypergraph(kahypar_hypergraph_t* kahypar_hypergraph,
+                                  const kahypar_partition_id_t num_blocks,
+                                  const double epsilon,
+                                  kahypar_hyperedge_weight_t* objective,
+                                  kahypar_context_t* kahypar_context,
+                                  kahypar_partition_id_t* partition) {
+  kahypar::Context& context = *reinterpret_cast<kahypar::Context*>(kahypar_context);
+  kahypar::Hypergraph& hypergraph = *reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);
+  ASSERT(!context.partition.use_individual_part_weights ||
+         !context.partition.max_part_weights.empty());
+  ASSERT(partition != nullptr);
+
+  context.partition.k = num_blocks;
+  context.partition.epsilon = epsilon;
+  context.partition.write_partition_file = false;
+
+  if (context.partition.vcycle_refinement_for_input_partition) {
+    for (const auto hn : hypergraph.nodes()) {
+      hypergraph.setNodePart(hn, partition[hn]);
+    }
+  }
+
+  kahypar::PartitionerFacade().partition(hypergraph, context);
+
+  *objective = kahypar::metrics::correctMetric(hypergraph, context);
+
+  for (const auto hn : hypergraph.nodes()) {
+    partition[hn] = hypergraph.partID(hn);
+  }
+
+  context.partition.perfect_balance_part_weights.clear();
+  context.partition.max_part_weights.clear();
+  context.evolutionary.communities.clear();
+}
+
+
+void kahypar_improve_hypergraph_partition(kahypar_hypergraph_t* kahypar_hypergraph,
+                                          const kahypar_partition_id_t num_blocks,
+                                          const double epsilon,
+                                          kahypar_hyperedge_weight_t* objective,
+                                          kahypar_context_t* kahypar_context,
+                                          const kahypar_partition_id_t* input_partition,
+                                          const size_t num_improvement_iterations,
+                                          kahypar_partition_id_t* improved_partition) {
+  kahypar::Context& context = *reinterpret_cast<kahypar::Context*>(kahypar_context);
+  kahypar::Hypergraph& hypergraph = *reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);
+  ALWAYS_ASSERT(context.partition.mode == kahypar::Mode::direct_kway,
+                "V-cycle refinement of input partitions is only possible in direct k-way mode");
+  ASSERT(*std::max_element(input_partition, input_partition + hypergraph.initialNumNodes()) == num_blocks - 1);
+  ASSERT([&]() {
+    std::unordered_set<kahypar_partition_id_t> set(input_partition, input_partition + hypergraph.initialNumNodes());
+    LOG << V(set.size());
+    for (kahypar_partition_id_t i = 0; i < num_blocks; ++i) {
+      if (set.find(i) == set.end()) {
+        return false;
+      }
+    }
+    return true;
+  } (), "Partition is corrupted.");
+
+  // toggle v-cycle refinement
+  context.partition.vcycle_refinement_for_input_partition = true;
+  // perform one v-cycle
+  context.partition.global_search_iterations = num_improvement_iterations;
+  // sparsifier has to be disabled for v-cycle refinement
+  context.preprocessing.enable_min_hash_sparsifier = false;
+
+  // use improved_partition as temporary_input_partition
+  std::memcpy(improved_partition, input_partition, hypergraph.initialNumNodes() * sizeof(kahypar_partition_id_t));
+
+  kahypar_partition_hypergraph(kahypar_hypergraph,
+                               num_blocks,
+                               epsilon,
+                               objective,
+                               kahypar_context,
+                               improved_partition);
 }
 
 void kahypar_read_hypergraph_from_file(const char* file_name,
@@ -117,8 +241,7 @@ void kahypar_partition(const kahypar_hypernode_id_t num_vertices,
     }
   }
 
-  kahypar::PartitionerFacade partitioner;
-  partitioner.partition(hypergraph, context);
+  kahypar::PartitionerFacade().partition(hypergraph, context);
 
   *objective = kahypar::metrics::correctMetric(hypergraph, context);
 

--- a/tests/interface/interface_test.cc
+++ b/tests/interface/interface_test.cc
@@ -35,7 +35,7 @@ namespace kahypar {
 TEST(KaHyPar, CanBeCalledViaInterface) {
   kahypar_context_t* context = kahypar_context_new();
 
-  kahypar_configure_context_from_file(context, "../../../config/old_reference_configs/km1_direct_kway_sea18.ini");
+  kahypar_configure_context_from_file(context, "../../../config/km1_kKaHyPar_sea20.ini");
 
   const kahypar_hypernode_id_t num_vertices = 7;
   const kahypar_hyperedge_id_t num_hyperedges = 4;
@@ -97,11 +97,124 @@ TEST(KaHyPar, CanBeCalledViaInterface) {
   kahypar_context_free(context);
 }
 
+TEST(KaHyPar, CanHandleFixedVerticesViaInterface) {
+  const kahypar_hypernode_id_t num_vertices = 7;
+  const kahypar_hyperedge_id_t num_hyperedges = 4;
+
+  std::unique_ptr<size_t[]> hyperedge_indices =
+    std::make_unique<size_t[]>(5);
+
+  hyperedge_indices[0] = 0;
+  hyperedge_indices[1] = 2;
+  hyperedge_indices[2] = 6;
+  hyperedge_indices[3] = 9;
+  hyperedge_indices[4] = 12;
+
+  std::unique_ptr<kahypar_hypernode_id_t[]> hyperedges =
+    std::make_unique<kahypar_hypernode_id_t[]>(12);
+
+  // hypergraph from hMetis manual page 14
+  hyperedges[0] = 0;
+  hyperedges[1] = 2;
+  hyperedges[2] = 0;
+  hyperedges[3] = 1;
+  hyperedges[4] = 3;
+  hyperedges[5] = 4;
+  hyperedges[6] = 3;
+  hyperedges[7] = 4;
+  hyperedges[8] = 6;
+  hyperedges[9] = 2;
+  hyperedges[10] = 5;
+  hyperedges[11] = 6;
+
+  const double imbalance = 0.03;
+  const kahypar_partition_id_t k = 2;
+  kahypar_hyperedge_weight_t objective = 0;
+
+  kahypar_hypergraph_t* kahypar_hypergraph = kahypar_create_hypergraph(k,
+                                                                       num_vertices,
+                                                                       num_hyperedges,
+                                                                       hyperedge_indices.get(),
+                                                                       hyperedges.get(),
+                                                                       nullptr,
+                                                                       nullptr);
+
+  std::unique_ptr<kahypar_partition_id_t[]> fixed_vertices = std::make_unique<kahypar_partition_id_t[]>(7);
+  // vertex 1 and 5 are fixed to blocks 0/1
+  fixed_vertices[0] = -1;
+  fixed_vertices[1] = 0;
+  fixed_vertices[2] = -1;
+  fixed_vertices[3] = -1;
+  fixed_vertices[4] = -1;
+  fixed_vertices[5] = 1;
+  fixed_vertices[6] = -1;
+
+  kahypar_set_fixed_vertices(kahypar_hypergraph, fixed_vertices.get());
+
+  Hypergraph& hypergraph = *reinterpret_cast<Hypergraph*>(kahypar_hypergraph);
+
+  ASSERT_FALSE(hypergraph.isFixedVertex(0));
+  ASSERT_TRUE(hypergraph.isFixedVertex(1));
+  ASSERT_FALSE(hypergraph.isFixedVertex(2));
+  ASSERT_FALSE(hypergraph.isFixedVertex(3));
+  ASSERT_FALSE(hypergraph.isFixedVertex(4));
+  ASSERT_TRUE(hypergraph.isFixedVertex(5));
+  ASSERT_FALSE(hypergraph.isFixedVertex(6));
+
+  kahypar_context_t* context = kahypar_context_new();
+  kahypar_configure_context_from_file(context, "../../../config/km1_kKaHyPar_sea20.ini");
+
+  std::vector<kahypar_partition_id_t> partition(num_vertices, -1);
+  kahypar_partition_hypergraph(kahypar_hypergraph, k, imbalance, &objective, context, partition.data());
+
+  for (kahypar_hypernode_id_t i = 0; i != num_vertices; ++i) {
+    LOG << V(i) << V(partition[i]);
+  }
+
+  ASSERT_TRUE(hypergraph.partID(1) == 0);
+  ASSERT_TRUE(hypergraph.partID(5) == 1);
+
+
+  // Make partition worse by moving vertex 4 to block 0 and then improve partition again.
+  ASSERT_TRUE(hypergraph.partID(4) == 1);
+  partition[4] = 0;
+  hypergraph.reset();
+
+  ASSERT_FALSE(hypergraph.isFixedVertex(0));
+  ASSERT_TRUE(hypergraph.isFixedVertex(1));
+  ASSERT_FALSE(hypergraph.isFixedVertex(2));
+  ASSERT_FALSE(hypergraph.isFixedVertex(3));
+  ASSERT_FALSE(hypergraph.isFixedVertex(4));
+  ASSERT_TRUE(hypergraph.isFixedVertex(5));
+  ASSERT_FALSE(hypergraph.isFixedVertex(6));
+
+  std::vector<kahypar_partition_id_t> improved_partition(num_vertices, -1);
+  kahypar_improve_hypergraph_partition(kahypar_hypergraph,
+                                       k,
+                                       imbalance,
+                                       &objective,
+                                       context,
+                                       partition.data(),
+                                       5,
+                                       improved_partition.data());
+
+  for (kahypar_hypernode_id_t i = 0; i != num_vertices; ++i) {
+    LOG << V(i) << V(improved_partition[i]);
+  }
+
+  ASSERT_TRUE(hypergraph.partID(1) == 0);
+  ASSERT_TRUE(hypergraph.partID(5) == 1);
+  ASSERT_TRUE(hypergraph.partID(4) == 0);
+
+  kahypar_context_free(context);
+  kahypar_hypergraph_free(kahypar_hypergraph);
+}
+
 
 TEST(KaHyPar, CanImprovePartitionsViaInterface) {
   kahypar_context_t* context = kahypar_context_new();
 
-  kahypar_configure_context_from_file(context, "../../../config/old_reference_configs/km1_direct_kway_sea18.ini");
+  kahypar_configure_context_from_file(context, "../../../config/old_reference_configs/km1_direct_kway_sea17.ini");
 
   // lower contraction limit to enforce contractions
   reinterpret_cast<kahypar::Context*>(context)->coarsening.contraction_limit_multiplier = 1;
@@ -186,10 +299,76 @@ TEST(KaHyPar, CanImprovePartitionsViaInterface) {
   kahypar_context_free(context);
 }
 
+TEST(KaHyPar, CanCreateHypergraphsViaInterface) {
+  const kahypar_hypernode_id_t num_vertices = 7;
+  const kahypar_hyperedge_id_t num_hyperedges = 4;
+
+  std::unique_ptr<size_t[]> hyperedge_indices =
+    std::make_unique<size_t[]>(5);
+
+  hyperedge_indices[0] = 0;
+  hyperedge_indices[1] = 2;
+  hyperedge_indices[2] = 6;
+  hyperedge_indices[3] = 9;
+  hyperedge_indices[4] = 12;
+
+  std::unique_ptr<kahypar_hypernode_id_t[]> hyperedges =
+    std::make_unique<kahypar_hypernode_id_t[]>(12);
+
+  // hypergraph from hMetis manual page 14
+  hyperedges[0] = 0;
+  hyperedges[1] = 2;
+  hyperedges[2] = 0;
+  hyperedges[3] = 1;
+  hyperedges[4] = 3;
+  hyperedges[5] = 4;
+  hyperedges[6] = 3;
+  hyperedges[7] = 4;
+  hyperedges[8] = 6;
+  hyperedges[9] = 2;
+  hyperedges[10] = 5;
+  hyperedges[11] = 6;
+
+  const double imbalance = 0.03;
+  const kahypar_partition_id_t k = 2;
+  kahypar_hyperedge_weight_t objective = 0;
+
+  std::unique_ptr<kahypar_hyperedge_weight_t[]> hyperedge_weights =
+    std::make_unique<kahypar_hyperedge_weight_t[]>(4);
+
+  hyperedge_weights[0] = 1000;
+  hyperedge_weights[1] = 1;
+  hyperedge_weights[2] = 1;
+  hyperedge_weights[3] = 1;
+
+
+  Hypergraph verification_hypergraph(num_vertices,
+                                     num_hyperedges,
+                                     hyperedge_indices.get(),
+                                     hyperedges.get(),
+                                     k,
+                                     hyperedge_weights.get(),
+                                     nullptr);
+
+  kahypar_hypergraph_t* kahypar_hypergraph = kahypar_create_hypergraph(k,
+                                                                       num_vertices,
+                                                                       num_hyperedges,
+                                                                       hyperedge_indices.get(),
+                                                                       hyperedges.get(),
+                                                                       hyperedge_weights.get(),
+                                                                       nullptr);
+
+  Hypergraph& hypergraph = *reinterpret_cast<Hypergraph*>(kahypar_hypergraph);
+
+  ASSERT_TRUE(verifyEquivalenceWithoutPartitionInfo(hypergraph, verification_hypergraph));
+
+  kahypar_hypergraph_free(kahypar_hypergraph);
+}
+
 
 TEST(KaHyPar, SupportsIndividualBlockWeightsViaInterface) {
   kahypar_context_t* context = kahypar_context_new();
-  kahypar_configure_context_from_file(context, "../../../config/old_reference_configs/km1_direct_kway_sea18.ini");
+  kahypar_configure_context_from_file(context, "../../../config/km1_kKaHyPar_sea20.ini");
 
   reinterpret_cast<kahypar::Context*>(context)->preprocessing.enable_community_detection = false;
 
@@ -426,6 +605,25 @@ TEST_F(AHypergraphFileWithHypernodeAndHyperedgeWeights, CanBeParsedIntoAHypergra
   delete[] hyperedges_ptr;
   delete[] hyperedge_weights_ptr;
   delete[] vertex_weights_ptr;
+}
+
+TEST_F(AHypergraphFileWithHypernodeAndHyperedgeWeights, CanBeParsedIntoKaHyParAHypergraph) {
+  kahypar_partition_id_t num_blocks = 8;
+
+  kahypar_hypergraph_t* kahypar_hypergraph = kahypar_create_hypergraph_from_file(_filename.c_str(),
+                                                                                 num_blocks);
+
+  Hypergraph& hypergraph = *reinterpret_cast<Hypergraph*>(kahypar_hypergraph);
+
+  ASSERT_TRUE(verifyEquivalenceWithoutPartitionInfo(Hypergraph(_control_num_hypernodes,
+                                                               _control_num_hyperedges,
+                                                               _control_index_vector,
+                                                               _control_edge_vector,
+                                                               8,
+                                                               &_control_hyperedge_weights,
+                                                               &_control_hypernode_weights),
+                                                    hypergraph));
+  kahypar_hypergraph_free(kahypar_hypergraph);
 }
 }  // namespace io
 }  // namespace kahypar


### PR DESCRIPTION
This PR introduces a `kahypar_hypergraph_t` type to pass hypergraphs around using the C interface. Furthermore, it extends the C interface such that it can work with fixed vertices.

The feature was requested for the Julia interface in https://github.com/kahypar/KaHyPar.jl/issues/1