### PR TITLE
Metrics bug

### DIFF
--- a/kahypar/partition/refinement/flow/2way_hyperflowcutter_refiner.h
+++ b/kahypar/partition/refinement/flow/2way_hyperflowcutter_refiner.h
@@ -272,7 +272,7 @@ class TwoWayHyperFlowCutterRefiner final : public IRefiner,
       } else if (newLocalImbalance < prevLocalImbalance) {
         refinement_result = std::max(refinement_result, RefinementResult::LocalBalanceImproved);
       } else {
-        ASSERT(false, "HFC succeeded but it improved neither metric nor local balance.");
+      	// cut did not get better or worse. balance stayed the same. --> don't update partition
         return false;
       }
 

--- a/kahypar/partition/refinement/flow/2way_hyperflowcutter_refiner.h
+++ b/kahypar/partition/refinement/flow/2way_hyperflowcutter_refiner.h
@@ -96,7 +96,7 @@ class TwoWayHyperFlowCutterRefiner final : public IRefiner,
   }
 
   bool refineImpl(std::vector<HypernodeID>&, const std::array<HypernodeWeight, 2>&,
-                  const UncontractionGainChanges&, Metrics&) override final {
+                  const UncontractionGainChanges&, Metrics& best_metrics) override final {
     if (!_flow_execution_policy.executeFlow(_hg) && !_ignore_flow_execution_policy) {
       return false;
     }
@@ -172,6 +172,11 @@ class TwoWayHyperFlowCutterRefiner final : public IRefiner,
           if (from != to)
             _quotient_graph->changeNodePart(uGlobal, from, to);
         }
+        
+        ASSERT(STF.cutAtStake >= newCut);
+        best_metrics.km1 -= (STF.cutAtStake - newCut);
+        best_metrics.imbalance = metrics::imbalance(_hg, _context);
+        HEAVY_REFINEMENT_ASSERT(best_metrics.km1 == metrics::km1(_hg), V(best_metrics.km1) << V(metrics::km1(_hg)));
 
         DBG << "Update partition" << V(metrics::imbalance(_hg, _context)) << V(b0) << V(b1) << V(_hg.currentNumNodes());
         if (_hg.partWeight(b0) > _context.partition.max_part_weights[b0] || _hg.partWeight(b1) > _context.partition.max_part_weights[b1]) {

--- a/kahypar/partition/refinement/flow/whfc_flow_hypergraph_extraction.h
+++ b/kahypar/partition/refinement/flow/whfc_flow_hypergraph_extraction.h
@@ -112,7 +112,7 @@ class FlowHypergraphExtractor {
         flow_hg_builder.removeCurrentHyperedge();
         result.baseCut += hg.edgeWeight(e);
       } else {
-        ASSERT(!flow_hg_builder.currentHyperedgeSize() == 0, "he in cut but has no pin in flow hg, except maybe one terminal");
+        ASSERT(flow_hg_builder.currentHyperedgeSize() != 0, "he in cut but has no pin in flow hg, except maybe one terminal");
         if (connectToSource)
           flow_hg_builder.addPin(result.source);
         if (connectToTarget)

--- a/tests/interface/interface_test.cc
+++ b/tests/interface/interface_test.cc
@@ -213,9 +213,8 @@ TEST(KaHyPar, CanHandleFixedVerticesViaInterface) {
 
 TEST(KaHyPar, CanImprovePartitionsViaInterface) {
   kahypar_context_t* context = kahypar_context_new();
-
-  kahypar_configure_context_from_file(context, "../../../config/old_reference_configs/km1_direct_kway_sea17.ini");
-
+  kahypar_configure_context_from_file(context, "../../../config/km1_kKaHyPar_sea20.ini");
+  
   // lower contraction limit to enforce contractions
   reinterpret_cast<kahypar::Context*>(context)->coarsening.contraction_limit_multiplier = 1;
 


### PR DESCRIPTION
This PR fixes a bug in which the best_metrics object wasn't updated in HyperFlowCutter refinement code.
Additionally, removes a wrong assertion, fixes a warning, and uses the most recent config in one of the interface tests.