### PR TITLE
Flow extraction

### DIFF
--- a/kahypar/datastructure/hypergraph.h
+++ b/kahypar/datastructure/hypergraph.h
@@ -1520,6 +1520,10 @@ class GenericHypergraph {
     return fixedVertexPartID(hn) != kInvalidPartition;
   }
 
+  bool hasFixedVertices() const {
+    return _fixed_vertices.operator bool();
+  }
+
   // ! Returns true if the hypernode is enabled
   // ! This is mainly used in assertions.
   bool nodeIsEnabled(const HypernodeID u) const {

--- a/kahypar/partition/refinement/flow/2way_hyperflowcutter_refiner.h
+++ b/kahypar/partition/refinement/flow/2way_hyperflowcutter_refiner.h
@@ -162,7 +162,7 @@ class TwoWayHyperFlowCutterRefiner final : public IRefiner,
       // assign new partition IDs
       if (should_update) {
         improved = true;
-        for (const whfc::Node uLocal : extractor.localNodeIDs()) {
+        for (whfc::Node uLocal(0); uLocal < extractor.numSnapshotNodes(); ++uLocal) {
           if (uLocal == STF.source || uLocal == STF.target)
             continue;
           const HypernodeID uGlobal = extractor.local2global(uLocal);
@@ -227,7 +227,7 @@ class TwoWayHyperFlowCutterRefiner final : public IRefiner,
   }
 
 
-  void writeSnapshot(whfcInterface::FlowHypergraphExtractor::AdditionalData& STF) {
+  void writeSnapshot(whfcInterface::FlowHypergraphExtractor::SnapshotData& STF) {
     whfc::WHFC_IO::WHFCInformation i = {
       { whfc::NodeWeight(_context.partition.max_part_weights[b0]), whfc::NodeWeight(_context.partition.max_part_weights[b1]) },
       STF.cutAtStake - STF.baseCut, STF.source, STF.target

--- a/kahypar/partition/refinement/flow/whfc_flow_hypergraph_extraction.h
+++ b/kahypar/partition/refinement/flow/whfc_flow_hypergraph_extraction.h
@@ -65,7 +65,7 @@ class FlowHypergraphExtractor {
   };
 
   SnapshotData run(const Hypergraph& hg, const Context& context, std::vector<HyperedgeID>& cut_hes,
-                     const PartitionID _b0, const PartitionID _b1, whfc::DistanceFromCut& distanceFromCut) {
+                   const PartitionID _b0, const PartitionID _b1, whfc::DistanceFromCut& distanceFromCut) {
     reset(_b0, _b1);
     SnapshotData result;
     whfc::HopDistance hop_distance_delta = context.local_search.hyperflowcutter.use_distances_from_cut ? 1 : 0;
@@ -87,6 +87,7 @@ class FlowHypergraphExtractor {
     /*
     if (hg.hasFixedVertices()) {
        TODO clean out fixed vertices in postprocessing instead of during the BFS to make the common case faster
+       Additionally this should prevent future changes made to the extraction to break stuff with fixed vertices
     }
     */
 

--- a/kahypar/partition/refinement/flow/whfc_flow_hypergraph_extraction.h
+++ b/kahypar/partition/refinement/flow/whfc_flow_hypergraph_extraction.h
@@ -38,6 +38,7 @@ namespace kahypar {
 namespace whfcInterface {
 class FlowHypergraphExtractor {
  public:
+  static constexpr bool debug = false;
   static constexpr HypernodeID invalid_node = std::numeric_limits<HypernodeID>::max();
   static constexpr PartitionID invalid_part = std::numeric_limits<PartitionID>::max();
 
@@ -90,6 +91,16 @@ class FlowHypergraphExtractor {
        Additionally this should prevent future changes made to the extraction to break stuff with fixed vertices
     }
     */
+
+    HEAVY_REFINEMENT_ASSERT([&]() {
+      for (HypernodeID u : hg.nodes()) {
+        if (hg.isFixedVertex(u) && global2local(u) != whfc::invalidNode) {
+          DBG << "Fixed vertex" << V(u) << V(global2local(u)) << "included in the snapshot for FlowCutter refinement.";
+          return false;
+        }
+      }
+      return true;
+    }());
 
     whfc::NodeWeight ws(hg.partWeight(b0) - w0), wt(hg.partWeight(b1) - w1);
     if (ws == 0 || wt == 0) {

--- a/tests/partition/fixed_vertex_test.cc
+++ b/tests/partition/fixed_vertex_test.cc
@@ -98,4 +98,32 @@ TEST_F(FixedVertex, AssignmentToBestPartitionIfKm1IsObjective) {
                 hypergraph->partID(5) == 0,
                 hypergraph->partID(6) == 0));
 }
+
+TEST_F(FixedVertex, FlowSnapshotDoesNotContainFixedVertices) {
+  // have to set manually, whereas fixed_vertices::partition already does that
+  hypergraph->setNodePart(0, 1);
+  hypergraph->setNodePart(6, 0);
+
+  // get the entire hypergraph in the snapshot
+  context.local_search.hyperflowcutter.flowhypergraph_size_constraint = FlowHypergraphSizeConstraint::part_weight_fraction;
+  context.local_search.hyperflowcutter.snapshot_scaling = 1.2;
+
+  context.partition.objective = Objective::km1;
+  whfcInterface::FlowHypergraphExtractor extractor(*hypergraph, context);
+  whfc::DistanceFromCut dummy_distance_tracker(hypergraph->initialNumNodes());
+
+  std::vector<HyperedgeID> cut_hes;
+  for (HyperedgeID e : hypergraph->edges()) {
+    if (hypergraph->connectivity(e) > 1) {
+      cut_hes.push_back(e);
+    }
+  }
+  auto r = extractor.run(*hypergraph, context, cut_hes, 0, 1, dummy_distance_tracker);
+
+  ASSERT_EQ(extractor.global2local(0), whfc::invalidNode);  // means they were not mapped!
+  ASSERT_EQ(extractor.global2local(6), whfc::invalidNode);
+  ASSERT_EQ(extractor.flow_hg_builder.nodeWeight(r.source), 1);
+  ASSERT_EQ(extractor.flow_hg_builder.nodeWeight(r.target), 1);
+}
+
 }  // namespace kahypar


### PR DESCRIPTION
Hi Sebastian,

this PR introduces two changes.

<del>1) It fixes a bug where boundary vertices that are fixed to a block could be included in the snapshot for FlowCutter refinement and thus could be moved. I've added a test and a heavy refinement assertion to check for this.</del> (was fixed in PR #66)

1) It optimizes away checks for fixed vertices if there aren't any. This gave a 10% performance improvement on my favorite test instance -- for FlowCutter refinement, not just extraction!

2) It reduces the number of passes over the cut hyperedges from 3 to 1. This should slightly increase performance, specifically for super low diameter snapshots, e.g. for dual SAT.
This changes the node ID setup of the snapshot slightly. Previously nodes from a block had consecutive IDs, which may or may not influence the refinement quality.  As soon as the remaining experiments for the overview paper are done, I will start another KaHyPar run.

Best,
Lars