### PR TITLE
Use `_WIN32` macro to check for Windows and fix case of `windows.h` header file

### DIFF
--- a/kahypar/application/command_line_options.h
+++ b/kahypar/application/command_line_options.h
@@ -22,8 +22,8 @@
 
 #include <boost/program_options.hpp>
 
-#if defined(_MSC_VER)
-#include <Windows.h>
+#if defined(_WIN32)
+#include <windows.h>
 #include <process.h>
 #else
 #include <sys/ioctl.h>
@@ -42,7 +42,7 @@ namespace kahypar {
 namespace platform {
 int getTerminalWidth() {
   int columns = 0;
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
   columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
@@ -55,7 +55,7 @@ int getTerminalWidth() {
 }
 
 int getProcessID() {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   return _getpid();
 #else
   return getpid();


### PR DESCRIPTION
Windows is usually run on case-insensitive file systems, on the other hand MinGW
is usually employed to cross-compile code for Windows on Linux, using most of
the time case-sensitive file systems, so that cases matter.  MinGW consistently
uses lowercase names for all header files.