### PR TITLE
Use BUILD_TESTING to disable/enable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PROJECT_DESCRIPTION "KaHyPar: Karlsruhe Hypergraph Partitioning")
 
 set(CMAKE_CXX_STANDARD 17)
 
+include(CTest)
+
 include_directories(${PROJECT_SOURCE_DIR})
 
 find_package(Threads REQUIRED)
@@ -322,10 +324,15 @@ message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 message(STATUS "CMAKE_CXX_FLAGS_RELEASE: ${CMAKE_CXX_FLAGS_RELEASE}")
 message(STATUS "CMAKE_CXX_FLAGS_DEBUG: ${CMAKE_CXX_FLAGS_DEBUG}")
 
-include(gmock)
-enable_testing()
+
 add_subdirectory(kahypar/application)
+
+if(BUILD_TESTING)
+  include(gmock)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+
 add_subdirectory(tools)
 add_subdirectory(lib)
-add_subdirectory(tests)
 add_subdirectory(python)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -72,17 +72,16 @@ add_executable(MtxToWeightedHgr mtx_to_weighted_hgr_converter.cc mtx_to_hgr_conv
 set_property(TARGET MtxToWeightedHgr PROPERTY CXX_STANDARD 14)
 set_property(TARGET MtxToWeightedHgr PROPERTY CXX_STANDARD_REQUIRED ON)
 
-
-
-# This test needs test instance files, so we copy them to the corresponding build dir
-file(COPY test_instances DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-add_gmock_test(bookshelf_to_hgr_converter_test bookshelf_to_hgr_converter_test.cc)
-add_gmock_test(mtx_to_hgr_converter_test mtx_to_hgr_converter_test.cc mtx_to_hgr_conversion.cc)
-add_gmock_test(cnf_to_hgr_converter_test cnf_to_hgr_converter_test.cc)
-add_gmock_test(hgr_to_edge_list_conversion_test hgr_to_edge_list_conversion_test.cc)
-add_gmock_test(repeats_to_hgr_conversion_test repeats_to_hgr_conversion_test.cc)
-add_gmock_test(hgr_to_mtx_test hgr_to_mtx_conversion_test.cc)
-
+if(BUILD_TESTING)
+  # This test needs test instance files, so we copy them to the corresponding build dir
+  file(COPY test_instances DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  add_gmock_test(bookshelf_to_hgr_converter_test bookshelf_to_hgr_converter_test.cc)
+  add_gmock_test(mtx_to_hgr_converter_test mtx_to_hgr_converter_test.cc mtx_to_hgr_conversion.cc)
+  add_gmock_test(cnf_to_hgr_converter_test cnf_to_hgr_converter_test.cc)
+  add_gmock_test(hgr_to_edge_list_conversion_test hgr_to_edge_list_conversion_test.cc)
+  add_gmock_test(repeats_to_hgr_conversion_test repeats_to_hgr_conversion_test.cc)
+  add_gmock_test(hgr_to_mtx_test hgr_to_mtx_conversion_test.cc)
+endif()
 
 #set_source_files_properties(hmetis_lib_test.cc PROPERTIES COMPILE_FLAGS -m32)
 #add_executable(hmetis_lib_test hmetis_lib_test.cc)


### PR DESCRIPTION
This PR uses CTest's `BUILD_TESTING` flag to enable/disable tests and addresses https://github.com/kahypar/kahypar/issues/87.