### PR TITLE
Add flag to build python interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ include_directories(SYSTEM ${gtest_SOURCE_DIR}/../googlemock/include ${gtest_SOU
 # add third-party algorithms to project
 include_directories(external_tools)
 
+option(KAHYPAR_PYTHON_INTERFACE
+  "Enable building the python interface" OFF)
+
 option(KAHYPAR_USE_MINIMAL_BOOST
   "Download boost automatically and compile required libraries." OFF)
 
@@ -98,9 +101,6 @@ if(KAHYPAR_USE_CPPCHECK)
       )
   endif(CMAKE_CXX_CPPCHECK)
 endif(KAHYPAR_USE_CPPCHECK)
-
-#find_package(Python ${PY_VERSION} REQUIRED)
-#find_package(PythonLibs ${PY_VERSION} REQUIRED)
 
 if(KAHYPAR_USE_GCOV)
    include(CodeCoverage)
@@ -335,4 +335,7 @@ endif()
 
 add_subdirectory(tools)
 add_subdirectory(lib)
-add_subdirectory(python)
+
+if(KAHYPAR_PYTHON_INTERFACE)
+  add_subdirectory(python)
+endif()

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ make uninstall-kahypar
 To compile the Python interface, do the following:
 
 1. Create a build directory: `mkdir build && cd build`
-2. Run cmake: `cmake .. -DCMAKE_BUILD_TYPE=RELEASE`
+2. Run cmake: `cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DKAHYPAR_PYTHON_INTERFACE=1`
 3. Go to libary folder: `cd python`
 4. Compile the libarary: `make`
 5. Copy the libary to your site-packages directory: `cp kahypar.so <path-to-site-packages>`


### PR DESCRIPTION
This PR addresses https://github.com/kahypar/kahypar/issues/85 and adds a `KAHYPAR_PYTHON_INTERFACE` cmake flag to control whether or not the python interface should be built. By default, this is set to `OFF`.

The PR also adjusts the README on how to uses this flag to build the interface.