### PR TITLE
Add 'KAHYPAR_USE_MINIMAL_BOOST'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,11 @@ class CMakeBuild(build_ext):
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(
             env.get('CXXFLAGS', ''), self.distribution.get_version())
 
+        if env.get('KAHYPAR_USE_MINIMAL_BOOST', 'OFF').upper() == 'ON':
+            cmake_args += ['-DKAHYPAR_PYTHON_INTERFACE=ON', 
+                           '-DKAHYPAR_USE_MINIMAL_BOOST=ON']
+            env['CXXFLAGS'] += ' -fPIC'
+
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(


### PR DESCRIPTION
Enable the installation of KaHyPar without the need to install the Boost library locally.

```
KAHYPAR_USE_MINIMAL_BOOST=ON pip install -U git+https://github.com/kahypar/kahypar --force-reinstall
```