### PR TITLE
min -> lowest in BinaryMinHeap

### DIFF
--- a/kahypar/datastructure/binary_heap.h
+++ b/kahypar/datastructure/binary_heap.h
@@ -416,7 +416,7 @@ class BinaryHeapTraits<BinaryMinHeap<IDType_, KeyType_> >{
   using Comparator = std::greater<KeyType>;
 
   static constexpr KeyType sentinel() {
-    return std::numeric_limits<KeyType_>::min();
+    return std::numeric_limits<KeyType_>::lowest();
   }
 };
 }  // namespace ds


### PR DESCRIPTION
Semantically, lowest should be used here. I don't know if floating point numbers are allowed as keys, but they would break with `min` instead of `lowest`.