### PR TITLE
Make sure hyperedges are sets

### DIFF
--- a/kahypar/io/hypergraph_io.h
+++ b/kahypar/io/hypergraph_io.h
@@ -27,7 +27,9 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
+#include <cstdlib>
 
 #include "kahypar/definitions.h"
 
@@ -79,6 +81,7 @@ static inline void readHypergraphFile(const std::string& filename, HypernodeID& 
     index_vector.push_back(edge_vector.size());
 
     std::string line;
+    std::unordered_set<HypernodeID> unique_pins;
     for (HyperedgeID i = 0; i < num_hyperedges; ++i) {
       std::getline(file, line);
       // skip any comments
@@ -103,10 +106,16 @@ static inline void readHypergraphFile(const std::string& filename, HypernodeID& 
         }
       }
       HypernodeID pin;
+      unique_pins.clear();
       while (line_stream >> pin) {
         // Hypernode IDs start from 0
         --pin;
         ASSERT(pin < num_hypernodes, "Invalid hypernode ID");
+        if (unique_pins.count(pin)) {
+          std::cerr << "Warning: Ignoring duplicate pin " << pin << " of hyperedge " << i << std::endl;
+          continue;
+        }
+        unique_pins.insert(pin);
         edge_vector.push_back(pin);
       }
       index_vector.push_back(edge_vector.size());

--- a/tests/io/hypergraph_io_test.cc
+++ b/tests/io/hypergraph_io_test.cc
@@ -248,5 +248,13 @@ TEST(AHypergraphDeathTest, WithEmptyHyperedgesLeadsToProgramExit) {
               ::testing::ExitedWithCode(1),
               "Error: Hyperedge 1 is empty");
 }
+
+TEST(DuplicatePins, GetRemovedDuringParsing) {
+  Hypergraph const hypergraph = createHypergraphFromFile("test_instances/corrupted_hypergraph_with_multiple_identical_pins.hgr", 2);
+  ASSERT_THAT(hypergraph.initialNumNodes(), Eq(3));
+  ASSERT_THAT(hypergraph.initialNumEdges(), Eq(2));
+  ASSERT_THAT(hypergraph.initialNumPins(), Eq(4));
+}
+
 }  // namespace io
 }  // namespace kahypar

--- a/tests/io/test_instances/corrupted_hypergraph_with_multiple_identical_pins.hgr
+++ b/tests/io/test_instances/corrupted_hypergraph_with_multiple_identical_pins.hgr
@@ -1,0 +1,4 @@
+% hypergraph with a hyperedge that contains a pin more than once
+2 3
+1 2 3
+2 2


### PR DESCRIPTION
KaHyPar assume hyperedges to be **sets** rather than **multisets**, i.e., a vertex can only be contained in a hyperedge once. If a hypergraph violates this assumption, coarsening will likely get stuck in an infinite loop.

This PR is motivated by https://github.com/kahypar/kahypar/issues/107 and removes any duplicated pins while reading in the hypergraph via `readHypergraphFile`. A warning is issued for each duplicate pin.