### PR TITLE
Make it possible to build as git submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 project(KaHyPar CXX C)
 set(PROJECT_VENDOR "Sebastian Schlag")


### PR DESCRIPTION
Hi,
Didn't take the time to handle duplicate pins yet. In the meantime, it would be nice to pull this: I build Kahypar as a git submodule with add_subdirectory in CMake, and this is required so that the Kahypar build does not assume it is at top level.
Regards,
Gabriel