### PR TITLE
Replace generic "Invalid object identifier" error message

### DIFF
--- a/kahypar/meta/abstract_factory.h
+++ b/kahypar/meta/abstract_factory.h
@@ -65,7 +65,7 @@ class Factory {
       return AbstractProductPtr((creator->second)(std::forward<ProductParameters>(params) ...));
     }
     LOG << "Could not load" << templateToString<IdentifierType>() << ": " << id;
-    LOG << "Please check you .ini config file.";
+    LOG << "Please check your .ini config file.";
     std::exit(-1);
   }
 

--- a/kahypar/meta/abstract_factory.h
+++ b/kahypar/meta/abstract_factory.h
@@ -26,6 +26,8 @@
 #include "kahypar/macros.h"
 #include "kahypar/meta/function_traits.h"
 #include "kahypar/meta/mandatory.h"
+#include "kahypar/meta/template_parameter_to_string.h"
+
 
 namespace kahypar {
 namespace meta {
@@ -62,7 +64,8 @@ class Factory {
     if (creator != _callbacks.end()) {
       return AbstractProductPtr((creator->second)(std::forward<ProductParameters>(params) ...));
     }
-    LOG << "Invalid object identifier";
+    LOG << "Could not load" << templateToString<IdentifierType>() << ": " << id;
+    LOG << "Please check you .ini config file.";
     std::exit(-1);
   }
 

--- a/tests/meta/static_multi_dispatch_factory_test.cc
+++ b/tests/meta/static_multi_dispatch_factory_test.cc
@@ -117,6 +117,15 @@ enum class PrintingAlgorithms : std::uint8_t {
   Printer2
 };
 
+static std::ostream& operator<< (std::ostream& os, const PrintingAlgorithms& algo) {
+  switch (algo) {
+    case PrintingAlgorithms::Printer1: return os << "Printer1";
+    case PrintingAlgorithms::Printer2: return os << "Printer2";
+      // omit default case to trigger compiler warning for missing cases
+  }
+  return os << static_cast<uint8_t>(algo);
+}
+
 enum class PrinterPolicyClasses : std::uint16_t {
   PrintA,
   PrintB,
@@ -126,6 +135,20 @@ enum class PrinterPolicyClasses : std::uint16_t {
   PrintDollar,
   PrintAt
 };
+
+static std::ostream& operator<< (std::ostream& os, const PrinterPolicyClasses& algo) {
+  switch (algo) {
+    case PrinterPolicyClasses::PrintA: return os << "PrintA";
+    case PrinterPolicyClasses::PrintB: return os << "PrintB";
+    case PrinterPolicyClasses::Print1: return os << "Print1";
+    case PrinterPolicyClasses::Print2: return os << "Print2";
+    case PrinterPolicyClasses::PrintHash: return os << "PrintHash";
+    case PrinterPolicyClasses::PrintDollar: return os << "PrintDollar";
+    case PrinterPolicyClasses::PrintAt: return os << "PrintAt";
+    // omit default case to trigger compiler warning for missing cases
+  }
+  return os << static_cast<uint16_t>(algo);
+}
 
 TEST(AStaticMultiDispatchFactory, AllowsDynamicSelectionOfStaticPolicies) {
   // Create a registry for printer policy classes


### PR DESCRIPTION
This PR is motivated by https://github.com/kahypar/kahypar/issues/122 and https://github.com/kahypar/kahypar/issues/130. In both issues, the root cause for the `Invalid object identifier` error message was that the configuration file did not match the KaHyPar version.

With this PR we now provide a more meaningful error message: For example, when commenting out 

```cpp
REGISTER_DISPATCHED_COARSENER(CoarseningAlgorithm::ml_style,
                              MLCoarseningDispatcher,
                              meta::PolicyRegistry<RatingFunction>::getInstance().getPolicy(
                                context.coarsening.rating.rating_function),
                              meta::PolicyRegistry<HeavyNodePenaltyPolicy>::getInstance().getPolicy(
                                context.coarsening.rating.heavy_node_penalty_policy),
                              meta::PolicyRegistry<CommunityPolicy>::getInstance().getPolicy(
                                context.coarsening.rating.community_policy),
                              meta::PolicyRegistry<RatingPartitionPolicy>::getInstance().getPolicy(
                                context.coarsening.rating.partition_policy),
                              meta::PolicyRegistry<AcceptancePolicy>::getInstance().getPolicy(
                                context.coarsening.rating.acceptance_policy),
                              meta::PolicyRegistry<FixVertexContractionAcceptancePolicy>::getInstance().getPolicy(
                                context.coarsening.rating.fixed_vertex_acceptance_policy));
```
in `register_coarsening_algorithms.h` and trying to use the `ml_style` coarsener, we now get the following error message:

```
Could not load  kahypar::CoarseningAlgorithm :  ml_style
Please check you .ini config file.
```
