### PR TITLE
Handle single-block partitioning

### DIFF
--- a/kahypar/partition/partitioner.h
+++ b/kahypar/partition/partitioner.h
@@ -67,18 +67,22 @@ static inline void partition(Hypergraph& hypergraph, const Context& context) {
         }
         return true;
       } ());
-  switch (context.partition.mode) {
-    case Mode::recursive_bisection:
-
-      recursive_bisection::partition(hypergraph, context);
-
-      break;
-    case Mode::direct_kway:
-      direct_kway::partition(hypergraph, context);
-      break;
-    case Mode::UNDEFINED:
-      LOG << "Partitioning Mode undefined!";
-      std::exit(-1);
+  if (context.partition.k == 1) {
+    for (const auto& hn : hypergraph.nodes()) {
+      hypergraph.setNodePart(hn, 0);
+    }
+  } else {
+    switch (context.partition.mode) {
+      case Mode::recursive_bisection:
+        recursive_bisection::partition(hypergraph, context);
+        break;
+      case Mode::direct_kway:
+        direct_kway::partition(hypergraph, context);
+        break;
+      case Mode::UNDEFINED:
+        LOG << "Partitioning Mode undefined!";
+        std::exit(-1);
+    }
   }
 }
 }  // namespace partition

--- a/tests/partition/partitioner_test.cc
+++ b/tests/partition/partitioner_test.cc
@@ -157,4 +157,13 @@ TEST_F(MultilevelPartitioning, CanUseVcyclesAsGlobalSearchStrategy) {
   DBG1 << metrics::hyperedgeCut(*hypergraph);
   metrics::hyperedgeCut(*hypergraph);
 }
+
+TEST_F(MultilevelPartitioning, CanHandleSingleBlockPartitioning) {
+  context.partition.k = 1;
+  multilevel::partition(*hypergraph, *coarsener, *refiner, context);
+  for (auto const& hn : hypergraph->nodes()) {
+      ASSERT_THAT(hypergraph->partID(hn), 0);
+  }
+}
+
 }  // namespace kahypar


### PR DESCRIPTION
This PR addresses https://github.com/kahypar/kahypar/issues/139 and fixes KaHyPar to correctly handle the case of `k=1`.
Prior to this PR, setting `k=1` resulted in a segmentation fault.