### PR TITLE
Allow setting seed through library interface

### DIFF
--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -60,6 +60,8 @@ KAHYPAR_API void kahypar_context_free(kahypar_context_t* kahypar_context);
 KAHYPAR_API void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                                      const char* ini_file_name);
 
+KAHYPAR_API void kahypar_set_seed(kahypar_context_t* kahypar_context, const int seed);
+
 KAHYPAR_API void kahypar_hypergraph_free(kahypar_hypergraph_t* hypergraph);
 
 KAHYPAR_API void kahypar_set_custom_target_block_weights(const kahypar_partition_id_t num_blocks,

--- a/lib/libkahypar.cc
+++ b/lib/libkahypar.cc
@@ -59,6 +59,11 @@ void kahypar_hypergraph_free(kahypar_hypergraph_t* kahypar_hypergraph) {
   delete reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);
 }
 
+void kahypar_set_seed(kahypar_context_t* kahypar_context, const int seed) {
+  kahypar::Context& context = *reinterpret_cast<kahypar::Context*>(kahypar_context);
+  context.partition.seed =seed;
+}
+
 
 void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                          const char* ini_file_name) {

--- a/tests/interface/interface_test.cc
+++ b/tests/interface/interface_test.cc
@@ -630,5 +630,19 @@ TEST_F(AHypergraphFileWithHypernodeAndHyperedgeWeights, CanBeParsedIntoKaHyParAH
                                                     hypergraph));
   kahypar_hypergraph_free(kahypar_hypergraph);
 }
+
+TEST(Seed, CanBeSetViaLibraryInterface) {
+  kahypar_context_t* context = kahypar_context_new();
+
+  kahypar_configure_context_from_file(context, "../../../config/km1_kKaHyPar_sea20.ini");
+
+  kahypar_set_seed(context, 42);
+
+  kahypar::Context& kahypar_context = *reinterpret_cast<kahypar::Context*>(context);
+
+  ASSERT_EQ(kahypar_context.partition.seed, 42);
+
+  kahypar_context_free(context);
+}
 }  // namespace io
 }  // namespace kahypar


### PR DESCRIPTION
This PR adds `kahypar_set_seed` to allow setting the seed through KaHyPar's library interface.