### PR TITLE
Allow writing partition file through Python interface

### DIFF
--- a/python/module.cpp
+++ b/python/module.cpp
@@ -249,6 +249,16 @@ If only one type of weights is required, the other argument has to be an empty l
         },
         "Seed for the random number generator",
         py::arg("seed"))
+       .def("writePartitionFile",[](Context& c, const bool decision) {
+          c.partition.write_partition_file = decision;
+        },
+        "Write the computed partition to the file specified with setPartitionFileName",
+        py::arg("bool"))
+      .def("setPartitionFileName",[](Context& c, const std::string file_name) {
+          c.partition.graph_partition_filename = file_name;
+        },
+        "Set the filename of the computed partition",
+        py::arg("file_name"))
       .def("suppressOutput",[](Context& c, const bool decision) {
           c.partition.quiet_mode = decision;
         },

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ with codecs.open('README.md', "r", encoding='utf-8') as fh:
 if __name__ == '__main__':
     setup(
         name='kahypar',
-        version='1.1.8',
+        version='1.3.3',
         description='Python Inferface for the Karlsruhe Hypergraph Partitioning Framework (KaHyPar)',
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR addresses https://github.com/kahypar/kahypar/issues/157 and allows to write partition files through the python interface. 

After setting 
```python
context.writePartitionFile(True)
```
, the computed partition is written to the file specified by 
```python
context.setPartitionFileName("<path/to/partition/file>")
```
.