### PR TITLE
Add input validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,21 @@ if(KAHYPAR_USE_STANDARD_ASSERTIONS)
   add_compile_definitions(KAHYPAR_USE_STANDARD_ASSERTIONS)
 endif(KAHYPAR_USE_STANDARD_ASSERTIONS)
 
+# definitions for input validation
+option(KAHYPAR_INPUT_VALIDATION
+  "Validate that the input is a correct hypergraph (both for CLI and C interface)." ON)
+
+option(KAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS
+  "During input validation, consider even recoverable issues as a fatal error." OFF)
+
+if(KAHYPAR_INPUT_VALIDATION)
+  add_compile_definitions(KAHYPAR_INPUT_VALIDATION)
+endif(KAHYPAR_INPUT_VALIDATION)
+
+if(KAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS)
+  add_compile_definitions(KAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS)
+endif(KAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS)
+
 # defintions for heavy asserts
 option(KAHYPAR_ENABLE_HEAVY_DATA_STRUCTURE_ASSERTIONS
   "Enable costly assertions for data structures." ON)

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ To start KaHyPar in recursive bisection mode (KaHyPar-R) optimizing the cut-net 
 
 All preset parameters can be overwritten by using the corresponding command line options.
 
+#### Input Validation
+
+When creating a hypergraph KaHyPar validates that the input is actually a correct hypergraph, otherwise printing an error and aborting.
+This applies both to hgr input files, the C interface and the Python interface. The runtime cost of the validation should be negligible in almost all cases.
+However, the input validation can also be disabled using the cmake flag `-DKAHYPAR_INPUT_VALIDATION=OFF`.
+
+Additionally, warnings are printed for non-fatal issues (e.g. hyperedges with duplicate pins).
+To treat non-fatal issues as hard errors instead, use the cmake flag `-DKAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS=ON`.
+
 Using the Library Interfaces
 -----------
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ int main(int argc, char* argv[]) {
 To compile the program using `g++` run:
 
 ```sh
-g++ -std=c++14 -DNDEBUG -O3 -I/usr/local/include -L/usr/local/lib -lkahypar -L/path/to/boost/lib -I/path/to/boost/include -lboost_program_options program.cc -o program
+g++ -std=c++14 -DNDEBUG -O3 -I/usr/local/include -L/usr/local/lib program.cc -o program -lkahypar
 ```
 
 To remove the library from your system use the provided uninstall target:

--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -99,8 +99,6 @@ KAHYPAR_API void kahypar_improve_hypergraph_partition(kahypar_hypergraph_t* kahy
                                                       kahypar_partition_id_t* improved_partition);
 
 
-KAHYPAR_API void kahypar_hypergraph_free(kahypar_hypergraph_t* kahypar_hypergraph);
-
 KAHYPAR_API void kahypar_read_hypergraph_from_file(const char* file_name,
                                                    kahypar_hypernode_id_t* num_vertices,
                                                    kahypar_hyperedge_id_t* num_hyperedges,

--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -22,6 +22,7 @@
 #define LIBKAHYPAR_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,6 +82,14 @@ KAHYPAR_API kahypar_hypergraph_t* kahypar_create_hypergraph(const kahypar_partit
                                                             const kahypar_hyperedge_id_t* hyperedges,
                                                             const kahypar_hyperedge_weight_t* hyperedge_weights,
                                                             const kahypar_hypernode_weight_t* vertex_weights);
+
+KAHYPAR_API bool kahypar_validate_input(const kahypar_hypernode_id_t num_vertices,
+                                        const kahypar_hyperedge_id_t num_hyperedges,
+                                        const size_t* hyperedge_indices,
+                                        const kahypar_hyperedge_id_t* hyperedges,
+                                        const kahypar_hyperedge_weight_t* hyperedge_weights,
+                                        const kahypar_hypernode_weight_t* vertex_weights,
+                                        const bool print_errors);
 
 KAHYPAR_API void kahypar_partition_hypergraph(kahypar_hypergraph_t* kahypar_hypergraph,
                                               const kahypar_partition_id_t num_blocks,

--- a/kahypar/application/kahypar.cc
+++ b/kahypar/application/kahypar.cc
@@ -41,7 +41,9 @@ int main(int argc, char* argv[]) {
 
   kahypar::Hypergraph hypergraph(
     kahypar::io::createHypergraphFromFile(context.partition.graph_filename,
-                                          context.partition.k));
+                                          context.partition.k,
+                                          VALIDATE_INPUT,
+                                          PROMOTE_WARNINGS_TO_ERRORS));
 
   kahypar::SerializeOnSignal::initialize(hypergraph, context);
 

--- a/kahypar/datastructure/fast_reset_flag_array.h
+++ b/kahypar/datastructure/fast_reset_flag_array.h
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include "kahypar/macros.h"

--- a/kahypar/io/hypergraph_io.h
+++ b/kahypar/io/hypergraph_io.h
@@ -33,63 +33,12 @@
 #include <cstdlib>
 
 #include "kahypar/definitions.h"
+#include "kahypar/utils/validate.h"
 
 namespace kahypar {
 namespace io {
 using Mapping = std::unordered_map<HypernodeID, HypernodeID>;
-
-class CheckedIStream {
- public:
-  explicit CheckedIStream(const std::string& line, size_t line_number = 0):
-    _current(line.c_str()), _next(nullptr), _end(line.c_str() + line.size()), _line_number(line_number) {
-      // whitespace at end of line is not considered an error
-      while (_end > _current && *(_end - 1) == ' ') {
-        --_end;
-      }
-    }
-
-  template<typename ResultT>
-  bool operator>>(ResultT& result) {
-    unsigned long long val = std::strtoull(_current, &_next, 10);
-    if (val == 0 && _next == _current && _next != _end) {
-      std::cerr << "Error: Expected positive number";
-      if (_line_number != 0) {
-        std::cerr << " (line " << _line_number << ")";
-      }
-      std::cerr << std::endl;
-      exit(1);
-    }
-
-    const ResultT max = std::numeric_limits<ResultT>::max();
-    if (val > static_cast<unsigned long long>(max)) {
-      std::cerr << "Error: ID is out of range: " << val << ", but maximum is " << max;
-      if (_line_number != 0) {
-        std::cerr << " (line " << _line_number << ")";
-      }
-      std::cerr << std::endl;
-      exit(1);
-    }
-
-    if (_current != _next) {
-      _current = _next;
-      result = static_cast<ResultT>(val);
-      return true;
-    }
-    return false;
-  }
-
-  bool empty() const {
-    char* p = nullptr;
-    std::strtoull(_current, &p, 10);
-    return p == _current && p == _end;
-  }
-
- private:
-  const char* _current;
-  char* _next;
-  const char* _end;
-  size_t _line_number;
-};
+using validate::CheckedIStream;
 
 static inline void getNextLine(std::ifstream& file, std::string& line, size_t& line_number) {
   std::getline(file, line);

--- a/kahypar/io/hypergraph_io.h
+++ b/kahypar/io/hypergraph_io.h
@@ -242,6 +242,8 @@ static inline Hypergraph createHypergraphFromFile(const std::string& filename,
     HighResClockTimepoint end = std::chrono::high_resolution_clock::now();
     Timer::instance().add(Timepoint::input_validation,
                           std::chrono::duration<double>(end - start).count());
+    return Hypergraph(num_hypernodes, num_hyperedges, index_vector, edge_vector,
+                      num_parts, &hyperedge_weights, &hypernode_weights, ignored_hes, ignored_pins);
   }
 
   return Hypergraph(num_hypernodes, num_hyperedges, index_vector, edge_vector,

--- a/kahypar/io/hypergraph_io.h
+++ b/kahypar/io/hypergraph_io.h
@@ -42,15 +42,14 @@ using Mapping = std::unordered_map<HypernodeID, HypernodeID>;
 using ErrorList = std::vector<validate::InputError>;
 using validate::CheckedIStream;
 
-static inline void getNextLine(std::ifstream& file, std::string& line, size_t& line_number) {
-  std::getline(file, line);
-  ++line_number;
-
-  // skip any comments
-  while (line[0] == '%') {
-    std::getline(file, line);
+static bool getNextLine(std::ifstream& file, std::string& line, size_t& line_number) {
+  bool success = false;
+  do {
+    success = static_cast<bool>(std::getline(file, line));
     ++line_number;
-  }
+    // skip any comments
+  } while (success && line[0] == '%');
+  return success;
 }
 
 static inline void readHGRHeader(std::ifstream& file, HyperedgeID& num_hyperedges,
@@ -162,8 +161,7 @@ static inline void readHypergraphFile(const std::string& filename, HypernodeID& 
       }
     }
 
-    getNextLine(file, line, line_number);
-    if (!CheckedIStream(line).empty()) {
+    if (getNextLine(file, line, line_number) && !CheckedIStream(line).empty()) {
       WARNING("Unexpected content after end of hypergraph data", line_number);
     }
     file.close();

--- a/kahypar/io/partitioning_output.h
+++ b/kahypar/io/partitioning_output.h
@@ -232,6 +232,9 @@ inline void printPartitioningResults(const Hypergraph& hypergraph,
 
     LOG << "\nTimings:";
     LOG << "Partition time                     =" << elapsed_seconds.count() << "s";
+    if (timings.input_validation > 0) {
+      LOG << "  + Input Validation               =" << timings.input_validation << "s";
+    }
     if (!context.partition_evolutionary && !context.partition.time_limited_repeated_partitioning) {
       LOG << "  + Preprocessing                  =" << timings.total_preprocessing << "s";
       LOG << "    | min hash sparsifier          =" << timings.pre_sparsifier << "s";

--- a/kahypar/macros.h
+++ b/kahypar/macros.h
@@ -306,3 +306,14 @@ void unused(T&&) {
 #define RED "\033[1;91m"
 #define BOLD "\033[1m"
 #define END "\033[0m"
+
+// Errors and warnings
+#define MESSAGE_1(msg) msg
+#define MESSAGE_2(msg, line_number) msg << " (line " << static_cast<size_t>(line_number) << ")"
+
+#define MESSAGE_(N) MESSAGE_ ## N
+#define MESSAGE_EVAL(N) MESSAGE_(N)
+#define MESSAGE(...) EXPAND(MESSAGE_EVAL(EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
+
+#define WARNING(...) std::cerr << "Warning: " << MESSAGE(__VA_ARGS__) << std::endl
+#define ERROR(...) std::cerr << "Error: " << MESSAGE(__VA_ARGS__) << std::endl; std::exit(1)

--- a/kahypar/macros.h
+++ b/kahypar/macros.h
@@ -307,7 +307,7 @@ void unused(T&&) {
 #define BOLD "\033[1m"
 #define END "\033[0m"
 
-// Errors and warnings
+// Errors, warnings and input validation
 #define MESSAGE_1(msg) msg
 #define MESSAGE_2(msg, line_number) msg << " (line " << static_cast<size_t>(line_number) << ")"
 
@@ -315,5 +315,18 @@ void unused(T&&) {
 #define MESSAGE_EVAL(N) MESSAGE_(N)
 #define MESSAGE(...) EXPAND(MESSAGE_EVAL(EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
 
-#define WARNING(...) std::cerr << "Warning: " << MESSAGE(__VA_ARGS__) << std::endl
 #define ERROR(...) std::cerr << "Error: " << MESSAGE(__VA_ARGS__) << std::endl; std::exit(1)
+
+#ifdef KAHYPAR_INPUT_VALIDATION
+  #define VALIDATE_INPUT true
+#else
+  #define VALIDATE_INPUT false
+#endif
+
+#ifdef KAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS
+  #define PROMOTE_WARNINGS_TO_ERRORS true
+  #define WARNING(...) ERROR(__VA_ARGS__)
+#else
+  #define PROMOTE_WARNINGS_TO_ERRORS false
+  #define WARNING(...) std::cerr << "Warning: " << MESSAGE(__VA_ARGS__) << std::endl
+#endif

--- a/kahypar/utils/timer.h
+++ b/kahypar/utils/timer.h
@@ -29,6 +29,7 @@
 
 namespace kahypar {
 enum class Timepoint : uint8_t {
+  input_validation,
   pre_sparsifier,
   pre_community_detection,
   coarsening,
@@ -79,10 +80,20 @@ class Timer {
       lk(context.partition.rb_lower_k),
       rk(context.partition.rb_upper_k),
       time(time) { }
+
+    Timing(const Timepoint& timepoint, const double& time) :
+      type(ContextType::main),
+      mode(Mode::direct_kway),
+      timepoint(timepoint),
+      v_cycle(0),
+      lk(0),
+      rk(0),
+      time(time) { }
   };
 
 
   struct Result {
+    double input_validation = 0.0;
     double pre_sparsifier = 0.0;
     double pre_community_detection = 0.0;
     double total_preprocessing = 0.0;
@@ -109,6 +120,10 @@ class Timer {
  public:
   void add(const Context& context, const Timepoint& timepoint, const double& time) {
     _timings.emplace_back(context, timepoint, time);
+  }
+
+  void add(const Timepoint& timepoint, const double& time) {
+    _timings.emplace_back(timepoint, time);
   }
 
   static Timer & instance() {
@@ -162,6 +177,9 @@ class Timer {
 
       if (timing.type == ContextType::main) {
         switch (timing.timepoint) {
+          case Timepoint::input_validation:
+            _result.input_validation = timing.time;
+            break;
           case Timepoint::pre_sparsifier:
             _result.pre_sparsifier = timing.time;
             break;

--- a/kahypar/utils/timer.h
+++ b/kahypar/utils/timer.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "kahypar/definitions.h"
+#include "kahypar/partition/context.h"
 
 namespace kahypar {
 enum class Timepoint : uint8_t {

--- a/kahypar/utils/validate.h
+++ b/kahypar/utils/validate.h
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of KaHyPar.
+ *
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "kahypar/definitions.h"
+#include "kahypar/datastructure/fast_reset_flag_array.h"
+
+namespace kahypar {
+namespace validate {
+
+using ds::FastResetFlagArray;
+
+/*!
+  * Helper class for reading a line and reporting syntactical errors
+  */
+class CheckedIStream {
+ public:
+  explicit CheckedIStream(const char* begin, const char* end, size_t line_number = 0):
+    _current(begin), _next(nullptr), _end(end), _line_number(line_number) {
+      // whitespace at end of line is not considered an error
+      while (_end > _current && *(_end - 1) == ' ') {
+        --_end;
+      }
+    }
+
+  explicit CheckedIStream(const std::string& line, size_t line_number = 0):
+    CheckedIStream(line.c_str(), line.c_str() + line.size(), line_number) { }
+
+  template<typename ResultT>
+  bool operator>>(ResultT& result) {
+    unsigned long long val = std::strtoull(_current, &_next, 10);
+    if (val == 0 && _next == _current && _next != _end) {
+      std::cerr << "Error: Expected positive number";
+      if (_line_number != 0) {
+        std::cerr << " (line " << _line_number << ")";
+      }
+      std::cerr << std::endl;
+      exit(1);
+    }
+
+    const ResultT max = std::numeric_limits<ResultT>::max();
+    if (val > static_cast<unsigned long long>(max)) {
+      std::cerr << "Error: ID is out of range: " << val << ", but maximum is " << max;
+      if (_line_number != 0) {
+        std::cerr << " (line " << _line_number << ")";
+      }
+      std::cerr << std::endl;
+      exit(1);
+    }
+
+    if (_current != _next) {
+      _current = _next;
+      result = static_cast<ResultT>(val);
+      return true;
+    }
+    return false;
+  }
+
+  bool empty() const {
+    char* p = nullptr;
+    std::strtoull(_current, &p, 10);
+    return p == _current && p == _end;
+  }
+
+ private:
+  const char* _current;
+  char* _next;
+  const char* _end;
+  size_t _line_number;
+};
+
+/*!
+  * Types of semantic errors in hypergraph input
+  */
+enum class InputErrorType : uint8_t {
+  FirstHyperedgeIndexNotZero,   // first entry in index array not zero
+  HyperedgeIndexDescending,     // index array is not in ascending order
+  HyperedgeOutOfBounds,         // size of hyperedge (according to index array) is larger than number of nodes
+  HyperedgeSizeZeroOrOne,       // size of hyperedge is zero or one
+  HyperedgeWeightZero,          // weight of hyperedge is zero
+  HyperedgeDuplicatePin,        // hyperedge contains duplicate pins
+  HyperedgeInvalidPin,          // pin index is not a valid hypernode ID
+  HypernodeWeightZero           // weight of hypernode is zero
+};
+
+bool isFatal(const InputErrorType& type) {
+  switch (type) {
+    case InputErrorType::FirstHyperedgeIndexNotZero:  return true;
+    case InputErrorType::HyperedgeIndexDescending:    return true;
+    case InputErrorType::HyperedgeOutOfBounds:        return true;
+    case InputErrorType::HyperedgeSizeZeroOrOne:      return false;
+    case InputErrorType::HyperedgeWeightZero:         return false;
+    case InputErrorType::HyperedgeDuplicatePin:       return false;
+    case InputErrorType::HyperedgeInvalidPin:         return true;
+    case InputErrorType::HypernodeWeightZero:         return true;
+  }
+  return true;
+}
+
+static std::ostream& operator<< (std::ostream& os, const InputErrorType& type) {
+  switch (type) {
+    case InputErrorType::FirstHyperedgeIndexNotZero:
+      return os << "First entry in hyperedge indices must be 0";
+    case InputErrorType::HyperedgeIndexDescending:
+      return os << "Hyperedge indices must be in ascending order";
+    case InputErrorType::HyperedgeOutOfBounds:
+      return os << "Hyperedge has too many entries";
+    case InputErrorType::HyperedgeSizeZeroOrOne:
+      return os << "Hyperedge with size 0 or 1";
+    case InputErrorType::HyperedgeWeightZero:
+      return os << "Hyperedge with weight 0";
+    case InputErrorType::HyperedgeDuplicatePin:
+      return os << "Hyperedge has duplicate pins";
+    case InputErrorType::HyperedgeInvalidPin:
+      return os << "Hyperedge has invalid pin. Each pin must be a valid vertex ID";
+    case InputErrorType::HypernodeWeightZero:
+      return os << "Vertices with weight 0 are not supported. The minimum allowed vertex weight is 1";
+  }
+  return os << static_cast<uint8_t>(type);
+}
+
+
+struct InputError {
+  InputErrorType error_type;   // type of the error
+  size_t element_index;        // index of erronous hyperedge/hypernode (zero if not available)
+};
+
+
+/*!
+* Checks the provided hypergraph input for semantic errors
+* (e.g. invalid hyperedge indices, invalid pins).
+* Returns true if at least one error was found.
+*
+* \param num_hypernodes Number of hypernodes |V|
+* \param num_hyperedges Number of hyperedges |E|
+* \param hyperedge_indices For each hyperedge e, hyperedge_indices stores the index of the
+*                          first pin in edge_vector that belongs to e.
+* \param hyperedges Stores the pins of all hyperedges.
+* \param hyperedge_weights Weight for each hyperedge
+* \param hypernode_weights Weight for each hypernode
+*
+* \param errors If not null, all found errors are accumulated here
+* \param ignored_hes If not null, hyperedges that should be ignored are accumulated here
+* \param ignored_pins If not null, pins that should be ignored are accumulated here
+*/
+bool validateInput(const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,
+                   const size_t* hyperedge_indices, const HypernodeID* hyperedges,
+                   const HyperedgeWeight* hyperedge_weights, const HypernodeWeight* vertex_weights,
+                   std::vector<InputError>* errors = nullptr,
+                   std::vector<HyperedgeID>* ignored_hes = nullptr,
+                   std::vector<size_t>* ignored_pins = nullptr) {
+  bool found_error = false;
+  auto report_error = [&](const InputErrorType type, const size_t index) {
+    if (errors != nullptr) {
+      errors->push_back(InputError{type, index});
+    }
+    found_error = true;
+  };
+
+  if (hyperedge_indices[0] != 0) {
+    report_error(InputErrorType::FirstHyperedgeIndexNotZero, 0);
+  }
+
+  FastResetFlagArray<HyperedgeID> pin_set(num_hypernodes);
+  // iterate through the input and report all errors
+  for (HyperedgeID he = 0; he < num_hyperedges; ++he) {
+    // check hyperedge_indices
+    bool ignore_hyperedge = false;
+    if (hyperedge_indices[he + 1] < hyperedge_indices[he]) {
+      report_error(InputErrorType::HyperedgeIndexDescending, he);
+      continue;  // no hyperedge here in any meaningful sense
+    } else if (hyperedge_indices[he + 1] - hyperedge_indices[he] <= 1) {
+      report_error(InputErrorType::HyperedgeSizeZeroOrOne, he);
+      ignore_hyperedge = true;
+    } else if (hyperedge_indices[he + 1] - hyperedge_indices[he] > num_hypernodes) {
+      // this check should hopefully prevent an overly long running time in case the indices are garbage
+      report_error(InputErrorType::HyperedgeOutOfBounds, he);
+      continue;
+    }
+    // check hyperedge_weight
+    if (hyperedge_weights != nullptr && hyperedge_weights[he] == 0) {
+      report_error(InputErrorType::HyperedgeWeightZero, he);
+      ignore_hyperedge = true;
+    }
+    if (ignore_hyperedge && ignored_hes != nullptr) {
+      ignored_hes->push_back(he);
+    }
+
+    // check pins
+    pin_set.reset();
+    bool invalid_pin = false;
+    bool duplicate_pin = false;
+    for (size_t i = hyperedge_indices[he]; i < hyperedge_indices[he + 1]; ++i) {
+      const HypernodeID hn = hyperedges[i];
+      bool ignore_pin = ignore_hyperedge; // all pins of an ignored hyperedge are also ignored
+      if (hn >= num_hypernodes) {
+        invalid_pin = true;
+      } else if (pin_set[hn]) {
+        duplicate_pin = true;
+        ignore_pin = true; // ignore duplicate pins
+      } else {
+        pin_set.set(hn);
+      }
+      if (ignore_pin && ignored_pins != nullptr) {
+        ignored_pins->push_back(i);
+      }
+    }
+    // Note: We report invalid/duplicate pins once per hyperedge to avoid emitting
+    // multiple errors for one line of the input file
+    if (invalid_pin) {
+      report_error(InputErrorType::HyperedgeInvalidPin, he);
+    }
+    if (duplicate_pin) {
+      report_error(InputErrorType::HyperedgeDuplicatePin, he);
+    }
+  }
+  if (vertex_weights != nullptr) {
+    for (HypernodeID hn = 0; hn < num_hypernodes; ++hn) {
+      if (vertex_weights[hn] == 0) {
+        report_error(InputErrorType::HypernodeWeightZero, hn);
+      }
+    }
+  }
+  return found_error;
+}
+
+
+/*!
+* Prints the list of errors, including line numbers if provided.
+*
+* \param num_hypernodes Number of hypernodes |V|
+* \param num_hyperedges Number of hyperedges |E|
+* \param errors List of errors from call to validateInput
+* \param line_numbers Mapping of hyperedge/vertex IDs to line of input file.
+*                     Must either be empty or have size num_hyperedges + num_hypernodes
+* \param promote_warnings_to_errors If true, non-fatal errors are reported as error instead of warning
+* \param out Output stream (default: stderr)
+*/
+void printErrors(const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,
+                 const std::vector<InputError>& errors,
+                 const std::vector<size_t>& line_numbers = {},
+                 bool promote_warnings_to_errors = false,
+                 std::ostream& out = std::cerr) {
+  ASSERT(line_numbers.empty() || line_numbers.size() >= static_cast<size_t>(num_hyperedges));
+  unused(num_hypernodes);
+
+  for (const InputError& e: errors) {
+    bool print_as_warning = !promote_warnings_to_errors && !isFatal(e.error_type);
+    bool references_hypernode = (e.error_type == InputErrorType::HypernodeWeightZero);
+
+    out << (print_as_warning ? "Warning: " : "Error: ") << e.error_type;
+    if (line_numbers.empty()) {
+      out << (references_hypernode ? " (Vertex " : " (Hyperedge ") << e.element_index << ")" << std::endl;
+    } else {
+      size_t line = references_hypernode ? num_hyperedges + e.element_index : e.element_index;
+      out << " (line " << line_numbers[line] << ")" << std::endl;
+    }
+  }
+}
+
+/*!
+* Returns whether the list of errors contains a fatal error (so that partitioning must be aborted).
+*
+* \param errors List of errors from call to validateInput
+* \param promote_warnings_to_errors If true, all errors are considered fatal
+*/
+bool containsFatalError(const std::vector<InputError>& errors, bool promote_warnings_to_errors = false) {
+  for (const InputError& e: errors) {
+    if (promote_warnings_to_errors || isFatal(e.error_type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace validate
+}  // namespace kahypar

--- a/kahypar/utils/validate.h
+++ b/kahypar/utils/validate.h
@@ -283,6 +283,13 @@ void printErrors(const HypernodeID num_hypernodes, const HyperedgeID num_hypered
       size_t line = references_hypernode ? num_hyperedges + e.element_index : e.element_index;
       out << " (line " << line_numbers[line] << ")" << std::endl;
     }
+    if (e.element_index + 1 == num_hyperedges
+        && (e.error_type == InputErrorType::HyperedgeIndexDescending
+            || e.error_type == InputErrorType::HyperedgeOutOfBounds)) {
+      // output additional help if the likely cause for the error is a missing sentinel element
+      out << "Help: The last element of 'hyperedge_indices' must be a sentinel with value equal to the number of pins"
+          << " (hyperedge_indices has one more element than the number of hyperedges)" << std::endl;
+    }
   }
 }
 

--- a/python/tests/test_kahypar.py
+++ b/python/tests/test_kahypar.py
@@ -83,7 +83,7 @@ class MainTest(unittest.TestCase):
     # partition hypergraph
     def test_partition_hypergraph(self):
         context = kahypar.Context()
-        context.loadINIconfiguration(mydir+"/../..//config/km1_kKaHyPar_dissertation.ini")
+        context.loadINIconfiguration(mydir+"/../../config/km1_kKaHyPar_sea20.ini")
 
         ibm01 = kahypar.createHypergraphFromFile(mydir+"/ISPD98_ibm01.hgr",2)
 

--- a/tests/datastructure/hypergraph_test.cc
+++ b/tests/datastructure/hypergraph_test.cc
@@ -54,6 +54,28 @@ TEST_F(AHypergraph, InitializesInternalHypergraphRepresentation) {
   ASSERT_THAT(hypergraph.edgeSize(3), Eq(3));
 }
 
+TEST_F(Test, InitializesInternalHypergraphRepresentationWithSkippedHEsAndPins) {
+  Hypergraph hypergraph(7, 6,
+    HyperedgeIndexVector { 0, /*ignored->*/3, 3, 7, /*ignored->*/10, 13,  /*sentinel*/ 17 },
+    HyperedgeVector { 0, 2, /*ignored->*/2, 0, 1, 3, 4, 3, 4, 6, /*ignored->*/0, 0, 0,/*<-ignored*/ 2, 5, /*ignored->*/6, 6 },
+    2, {1, 2, 3, 4, 5, 6}, {}, {1, 4}, {2, 10, 11, 12, 15});
+  ASSERT_THAT(hypergraph.currentNumNodes(), Eq(7));
+  ASSERT_THAT(hypergraph.currentNumEdges(), Eq(4));
+  ASSERT_THAT(hypergraph.currentNumPins(), Eq(12));
+  ASSERT_THAT(hypergraph.nodeDegree(0), Eq(2));
+  ASSERT_THAT(hypergraph.nodeDegree(1), Eq(1));
+  ASSERT_THAT(hypergraph.nodeDegree(2), Eq(2));
+  ASSERT_THAT(hypergraph.nodeDegree(3), Eq(2));
+  ASSERT_THAT(hypergraph.nodeDegree(4), Eq(2));
+  ASSERT_THAT(hypergraph.nodeDegree(5), Eq(1));
+  ASSERT_THAT(hypergraph.nodeDegree(6), Eq(2));
+
+  ASSERT_THAT(hypergraph.edgeSize(0), Eq(2));
+  ASSERT_THAT(hypergraph.edgeSize(1), Eq(4));
+  ASSERT_THAT(hypergraph.edgeSize(2), Eq(3));
+  ASSERT_THAT(hypergraph.edgeSize(3), Eq(3));
+}
+
 TEST_F(AHypergraph, ReturnsHyperNodeDegree) {
   ASSERT_THAT(hypergraph.nodeDegree(6), Eq(2));
 }

--- a/tests/interface/interface_test.cc
+++ b/tests/interface/interface_test.cc
@@ -380,6 +380,18 @@ TEST(KaHyPar, RejectsInvalidHypergraphViaInterface) {
               ::testing::ExitedWithCode(1), "");
 }
 
+TEST(KaHyPar, ValidatesInputViaInterface) {
+  kahypar_hypernode_id_t num_vertices = 2;
+  kahypar_hyperedge_id_t num_hyperedges = 2;
+  size_t hyperedge_indices[3] = {0, 2, 1}; // invalid index array
+  kahypar_hyperedge_id_t hyperedges[4] = {0, 1, 0, 1};
+
+  ASSERT_FALSE(kahypar_validate_input(num_vertices, num_hyperedges, hyperedge_indices,
+                                      hyperedges, nullptr, nullptr, false));
+  hyperedge_indices[2] = 4;
+  ASSERT_TRUE(kahypar_validate_input(num_vertices, num_hyperedges, hyperedge_indices,
+                                      hyperedges, nullptr, nullptr, false));
+}
 
 TEST(KaHyPar, SupportsIndividualBlockWeightsViaInterface) {
   kahypar_context_t* context = kahypar_context_new();

--- a/tests/interface/interface_test.cc
+++ b/tests/interface/interface_test.cc
@@ -368,6 +368,18 @@ TEST(KaHyPar, CanCreateHypergraphsViaInterface) {
   kahypar_hypergraph_free(kahypar_hypergraph);
 }
 
+TEST(KaHyPar, RejectsInvalidHypergraphViaInterface) {
+  kahypar_partition_id_t num_blocks = 2;
+  kahypar_hypernode_id_t num_vertices = 2;
+  kahypar_hyperedge_id_t num_hyperedges = 2;
+  size_t hyperedge_indices[3] = {0, 2, 1}; // invalid index array
+  kahypar_hyperedge_id_t hyperedges[2] = {0, 1};
+
+  EXPECT_EXIT(kahypar_create_hypergraph(num_blocks, num_vertices, num_hyperedges,
+                                        hyperedge_indices, hyperedges, nullptr, nullptr),
+              ::testing::ExitedWithCode(1), "");
+}
+
 
 TEST(KaHyPar, SupportsIndividualBlockWeightsViaInterface) {
   kahypar_context_t* context = kahypar_context_new();
@@ -629,6 +641,14 @@ TEST_F(AHypergraphFileWithHypernodeAndHyperedgeWeights, CanBeParsedIntoKaHyParAH
                                                                &_control_hypernode_weights),
                                                     hypergraph));
   kahypar_hypergraph_free(kahypar_hypergraph);
+}
+
+TEST(CorruptedHypergraphFile, IsRejectedByInputValidation) {
+  kahypar_partition_id_t num_blocks = 2;
+  std::string filename("test_instances/corrupted_hypergraph_with_invalid_pin.hgr");
+
+  EXPECT_EXIT(kahypar_create_hypergraph_from_file(filename.c_str(), num_blocks),
+              ::testing::ExitedWithCode(1), "");
 }
 
 TEST(Seed, CanBeSetViaLibraryInterface) {

--- a/tests/interface/test_instances/corrupted_hypergraph_with_invalid_pin.hgr
+++ b/tests/interface/test_instances/corrupted_hypergraph_with_invalid_pin.hgr
@@ -1,0 +1,3 @@
+% hypergraph with invalid pin (>2)
+1 2 0
+1 11

--- a/tests/io/hypergraph_io_test.cc
+++ b/tests/io/hypergraph_io_test.cc
@@ -257,5 +257,12 @@ TEST(DuplicatePins, GetRemovedDuringParsing) {
   ASSERT_THAT(hypergraph.initialNumPins(), Eq(4));
 }
 
+TEST(DuplicatePinsAndInvalidHes, GetRemovedDuringParsing) {
+  Hypergraph const hypergraph = createHypergraphFromFile("test_instances/corrupted_hypergraph_with_identical_pins_and_invalid_edges.hgr", 2);
+  ASSERT_THAT(hypergraph.initialNumNodes(), Eq(3));
+  ASSERT_THAT(hypergraph.initialNumEdges(), Eq(3));
+  ASSERT_THAT(hypergraph.initialNumPins(), Eq(6));
+}
+
 }  // namespace io
 }  // namespace kahypar

--- a/tests/io/hypergraph_io_test.cc
+++ b/tests/io/hypergraph_io_test.cc
@@ -34,8 +34,9 @@ TEST(AFunction, ParsesFirstLineOfaHGRFile) {
   HyperedgeID num_hyperedges = 0;
   HypernodeID num_hypernodes = 0;
   HypergraphType hypergraph_type = HypergraphType::Unweighted;
+  size_t line_number = 0;
 
-  readHGRHeader(file, num_hyperedges, num_hypernodes, hypergraph_type);
+  readHGRHeader(file, num_hyperedges, num_hypernodes, hypergraph_type, line_number);
   ASSERT_THAT(num_hyperedges, Eq(4));
   ASSERT_THAT(num_hypernodes, Eq(7));
   ASSERT_THAT(hypergraph_type, Eq(HypergraphType::Unweighted));
@@ -246,7 +247,7 @@ TEST(AHypergraph, CanBeSerializedToPaToHFormat) {
 TEST(AHypergraphDeathTest, WithEmptyHyperedgesLeadsToProgramExit) {
   EXPECT_EXIT(createHypergraphFromFile("test_instances/corrupted_hypergraph_with_empty_hyperedges.hgr", 2),
               ::testing::ExitedWithCode(1),
-              "Error: Hyperedge 1 is empty");
+              ""); // "Error: Hyperedge is empty (line 3)"); --> for some reason gtest ignores the output
 }
 
 TEST(DuplicatePins, GetRemovedDuringParsing) {

--- a/tests/io/test_instances/corrupted_hypergraph_with_identical_pins_and_invalid_edges.hgr
+++ b/tests/io/test_instances/corrupted_hypergraph_with_identical_pins_and_invalid_edges.hgr
@@ -1,0 +1,8 @@
+% hypergraph with a hyperedge that contains a pin more than once,
+% a hyperedge with size one and a hyperedge with weight zero
+5 3 01
+1 1
+2 1 2 3
+1 2 2
+0 1 2 3
+1 2 3

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_gmock_test(math_test math_test.cc)
+add_gmock_test(input_validation_test input_validation_test.cc)

--- a/tests/utils/input_validation_test.cc
+++ b/tests/utils/input_validation_test.cc
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of KaHyPar.
+ *
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include "gmock/gmock.h"
+
+#include <vector>
+
+#include "kahypar/definitions.h"
+#include "kahypar/utils/validate.h"
+
+using ::testing::Eq;
+using ::testing::Test;
+
+namespace kahypar {
+namespace validate {
+
+struct ValidateInputTest : public Test {
+  std::tuple<std::vector<InputError>, std::vector<HyperedgeID>, std::vector<size_t>> runValidation(
+    const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,
+    const std::vector<size_t>& hyperedge_indices, const std::vector<HypernodeID>& hyperedges,
+    const std::vector<HyperedgeWeight>& hyperedge_weights = {}, const std::vector<HypernodeWeight>& vertex_weights = {}
+  ) {
+    std::vector<InputError> errors;
+    std::vector<HyperedgeID> ignored_hes;
+    std::vector<size_t> ignored_pins;
+    validateInput(num_hypernodes, num_hyperedges, hyperedge_indices.data(), hyperedges.data(),
+                  hyperedge_weights.empty() ? nullptr : hyperedge_weights.data(),
+                  vertex_weights.empty() ? nullptr : vertex_weights.data(),
+                  &errors, &ignored_hes, &ignored_pins);
+    return {errors, ignored_hes, ignored_pins};
+  }
+
+  bool compareToExpected(const std::vector<InputError>& errors, const std::vector<InputError>& expected) {
+    if (errors.size() != expected.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < errors.size(); ++i) {
+      if (errors[i].error_type != expected[i].error_type || errors[i].element_index != expected[i].element_index) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+TEST_F(ValidateInputTest, ReportsEachError) {
+  std::vector<InputError> errors;
+  std::vector<HyperedgeID> hes;
+  std::vector<size_t> pins;
+
+  std::tie(errors, hes, pins) = runValidation(1, 0, {1}, {});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::FirstHyperedgeIndexNotZero, 0} }));
+
+  std::tie(errors, hes, pins) = runValidation(2, 2, {0, 2, 1}, {0, 1});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HyperedgeIndexDescending, 1} }));
+
+  std::tie(errors, hes, pins) = runValidation(1, 1, {0, 13}, {0});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HyperedgeOutOfBounds, 0} }));
+
+  std::tie(errors, hes, pins) = runValidation(1, 2, {0, 0, 1}, {0});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HyperedgeSizeZeroOrOne, 0},
+                                          InputError{InputErrorType::HyperedgeSizeZeroOrOne, 1} }));
+
+  std::tie(errors, hes, pins) = runValidation(2, 1, {0, 2}, {0, 1}, {0});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HyperedgeWeightZero, 0} }));
+
+  std::tie(errors, hes, pins) = runValidation(2, 1, {0, 2}, {0, 0});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HyperedgeDuplicatePin, 0} }));
+
+  std::tie(errors, hes, pins) = runValidation(2, 1, {0, 2}, {0, 13});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HyperedgeInvalidPin, 0} }));
+
+  std::tie(errors, hes, pins) = runValidation(1, 0, {0}, {}, {}, {0});
+  ASSERT_TRUE(compareToExpected(errors, { InputError{InputErrorType::HypernodeWeightZero, 0} }));
+}
+
+TEST_F(ValidateInputTest, ReportsMultipleErrors) {
+  auto [errors, hes, pins] = runValidation(4, 3, {0, 1, 4, 13}, {13, 1, 3, 3, 0});
+  ASSERT_TRUE(compareToExpected(errors, {
+    InputError{InputErrorType::HyperedgeSizeZeroOrOne, 0}, InputError{InputErrorType::HyperedgeInvalidPin, 0},
+    InputError{InputErrorType::HyperedgeDuplicatePin, 1}, InputError{InputErrorType::HyperedgeOutOfBounds, 2}
+  }));
+}
+
+TEST_F(ValidateInputTest, ReportsIgnoredHEsAndPins) {
+  auto [errors, hes, pins] = runValidation(4, 5, {0, 0, 1, 4, 6, 10}, {0, 1, 1, 2, 0, 1, 2, 3, 2, 2}, {1, 1, 1, 0, 1});
+  ASSERT_TRUE(compareToExpected(errors, {
+    InputError{InputErrorType::HyperedgeSizeZeroOrOne, 0}, InputError{InputErrorType::HyperedgeSizeZeroOrOne, 1},
+    InputError{InputErrorType::HyperedgeDuplicatePin, 2}, InputError{InputErrorType::HyperedgeWeightZero, 3},
+    InputError{InputErrorType::HyperedgeDuplicatePin, 4}
+  }));
+  ASSERT_EQ(hes.size(), 3);
+  ASSERT_EQ(hes[0], 0);
+  ASSERT_EQ(hes[1], 1);
+  ASSERT_EQ(hes[2], 3);
+  ASSERT_EQ(pins.size(), 6);
+  // note: pins of ignored hes are also ignored
+  ASSERT_EQ(pins[0], 0);
+  ASSERT_EQ(pins[1], 2);
+  ASSERT_EQ(pins[2], 4);
+  ASSERT_EQ(pins[3], 5);
+  ASSERT_EQ(pins[4], 8);
+  ASSERT_EQ(pins[5], 9);
+}
+
+}  // namespace math
+}  // namespace kahypar

--- a/tools/bookshelf_to_hgr_converter.h
+++ b/tools/bookshelf_to_hgr_converter.h
@@ -136,5 +136,5 @@ static inline std::unordered_map<std::string, HypernodeID> convertBookshelfToHgr
   }
   out_stream.close();
 
-  return std::move(node_to_hn);
+  return node_to_hn;
 }

--- a/tools/cnf_to_hgr_converter_test.cc
+++ b/tools/cnf_to_hgr_converter_test.cc
@@ -34,7 +34,7 @@ TEST(ACnfToHgrConversionRoutine, ConvertsCNFinstancesIntoLiteralHypergraphRepres
   std::string hgr_filename("test_instances/SampleSAT.cnf.hgr");
   convertInstance(cnf_filename, hgr_filename, HypergraphRepresentation::Literal);
 
-  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2);
+  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2, false);
 
   ASSERT_EQ(hypergraph.initialNumNodes(), 8);
   ASSERT_EQ(hypergraph.initialNumPins(), 8);
@@ -64,7 +64,7 @@ TEST(ACnfToHgrConversionRoutine, ConvertsCNFinstancesIntoPrimalHypergraphReprese
   std::string hgr_filename("test_instances/SampleSAT.cnf.hgr");
   convertInstance(cnf_filename, hgr_filename, HypergraphRepresentation::Primal);
 
-  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2);
+  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2, false);
 
   ASSERT_EQ(hypergraph.initialNumNodes(), 5);
   ASSERT_EQ(hypergraph.initialNumPins(), 8);
@@ -94,7 +94,7 @@ TEST(ACnfToHgrConversionRoutine, ConvertsCNFinstancesIntoDualHypergraphRepresent
   std::string hgr_filename("test_instances/SampleSAT.cnf.hgr");
   convertInstance(cnf_filename, hgr_filename, HypergraphRepresentation::Dual);
 
-  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2);
+  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2, false);
 
   ASSERT_EQ(hypergraph.initialNumNodes(), 3);
   ASSERT_EQ(hypergraph.initialNumPins(), 8);
@@ -136,7 +136,7 @@ TEST(ACnfToHgrConversionRoutine, IgnoresMissingVariablesInPrimalRepresentation) 
   std::string hgr_filename("test_instances/SampleSAT_missing_variables.cnf.hgr");
   convertInstance(cnf_filename, hgr_filename, HypergraphRepresentation::Primal);
 
-  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2);
+  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2, false);
 
   ASSERT_EQ(hypergraph.initialNumNodes(), 8);
   ASSERT_EQ(hypergraph.initialNumPins(), 10);
@@ -167,7 +167,7 @@ TEST(ACnfToHgrConversionRoutine, IgnoresMissingVariablesInDualRepresentation) {
   std::string hgr_filename("test_instances/SampleSAT_missing_variables.cnf.hgr");
   convertInstance(cnf_filename, hgr_filename, HypergraphRepresentation::Dual);
 
-  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2);
+  Hypergraph hypergraph = io::createHypergraphFromFile(hgr_filename, 2, false);
 
   ASSERT_EQ(hypergraph.initialNumNodes(), 3);
   ASSERT_EQ(hypergraph.initialNumPins(), 10);

--- a/tools/hgr_to_mtx_conversion_test.cc
+++ b/tools/hgr_to_mtx_conversion_test.cc
@@ -30,7 +30,7 @@ using ::testing::Test;
 namespace kahypar {
 TEST(AHypergraph, CanBeConvertedToMatrixMarketFormatForMondriaanPartitioning) {
   const std::string input_hypergraph_filename("test_instances/mondriaan_example.hgr");
-  Hypergraph input_hypergraph = kahypar::io::createHypergraphFromFile(input_hypergraph_filename, 2);
+  Hypergraph input_hypergraph = kahypar::io::createHypergraphFromFile(input_hypergraph_filename, 2, false);
 
   const std::string mtx_filename("test_instances/mondriaan_example.mtx");
 


### PR DESCRIPTION
Adds validation that the input is actually a correct hypergraph (currently, KaHyPar likely segfaults in such cases or even produces garbage output). This applies to hgr files as well as the C interface and the Python interface.

This includes three major changes:
 - When parsing a hgr file, all (or at least most) possibilities for syntactic errors are checked and cause an appropriate error message
 - Adds a new utility for checking semantic errors, which is called after parsing the hgr file or when creating a hypergraph via the according interface function. All found errors as well as warnings (e.g. duplicate pins) are reported, as well as hyperedges/pins that should be ignored
 - Adjusts the hypergraph constructor so it can handle ignored hyperedges/pins

The required time for the semantic checks is reported in the output. The checks can be disabled using the new flag `KAHYPAR_INPUT_VALIDATION`. Alternatively, all warnings can be promoted to errors using `KAHYPAR_INPUT_VALIDATION_PROMOTE_WARNINGS_TO_ERRORS`.