### PR TITLE
Config for cut-net optimization with kKaHyPar-E

### DIFF
--- a/config/cut_kKaHyPar-E_sea20.ini
+++ b/config/cut_kKaHyPar-E_sea20.ini
@@ -1,0 +1,93 @@
+# general
+mode=direct
+objective=cut
+seed=-1
+cmaxnet=1000
+vcycles=0
+time-limit=28800
+# main -> preprocessing -> min hash sparsifier
+p-use-sparsifier=true
+p-sparsifier-min-median-he-size=28
+p-sparsifier-max-hyperedge-size=1200
+p-sparsifier-max-cluster-size=10
+p-sparsifier-min-cluster-size=2
+p-sparsifier-num-hash-func=5
+p-sparsifier-combined-num-hash-func=100
+# main -> preprocessing -> community detection
+p-detect-communities=true
+p-detect-communities-in-ip=true
+p-reuse-communities=false
+p-max-louvain-pass-iterations=100
+p-min-eps-improvement=0.0001
+p-louvain-edge-weight=hybrid
+p-large-he-threshold=1000
+# main -> preprocessing -> large he removal
+p-smallest-maxnet-threshold=50000
+p-maxnet-removal-factor=0.01
+# main -> coarsening
+c-type=ml_style
+c-s=1
+c-t=160
+# main -> coarsening -> rating
+c-rating-score=heavy_edge
+c-rating-use-communities=true
+c-rating-heavy_node_penalty=no_penalty
+c-rating-acceptance-criterion=best_prefer_unmatched
+c-fixed-vertex-acceptance-criterion=fixed_vertex_allowed
+# main -> initial partitioning
+i-mode=recursive
+i-technique=multi
+# initial partitioning -> coarsening
+i-c-type=ml_style
+i-c-s=1
+i-c-t=150
+# initial partitioning -> coarsening -> rating
+i-c-rating-score=heavy_edge
+i-c-rating-use-communities=true
+i-c-rating-heavy_node_penalty=no_penalty
+i-c-rating-acceptance-criterion=best_prefer_unmatched
+i-c-fixed-vertex-acceptance-criterion=fixed_vertex_allowed
+# initial partitioning -> initial partitioning
+i-algo=pool
+i-runs=20
+# initial partitioning -> bin packing
+i-bp-algorithm=worst_fit
+i-bp-heuristic-prepacking=false
+i-bp-early-restart=true
+i-bp-late-restart=true
+# initial partitioning -> local search
+i-r-type=twoway_fm
+i-r-runs=-1
+i-r-fm-stop=simple
+i-r-fm-stop-i=50
+# main -> local search
+r-type=kway_fm_hyperflow_cutter
+r-runs=-1
+r-fm-stop=adaptive_opt
+r-fm-stop-alpha=1
+r-fm-stop-i=350
+# local_search -> flow scheduling and heuristics
+r-flow-execution-policy=exponential
+# local_search -> hyperflowcutter configuration
+r-hfc-size-constraint=mf-style
+r-hfc-scaling=16
+r-hfc-distance-based-piercing=true
+r-hfc-mbc=true
+#evolutionary
+partition-evolutionary=true
+population-size=10
+dynamic-population-size=true
+dynamic-population-time=0.15
+replace-strategy=strong-diverse
+diversify-interval=1
+#evolutionary -> combination
+combine-strategy=basic
+random-combine=true
+edge-frequency-chance=0.5
+edge-frequency-amount=3
+gamma=0.5
+unlimited-coarsening=true
+#evolutionary -> mutation
+mutate-strategy=new-initial-partitioning-vcycle
+mutate-chance=0.5
+random-vcycles=true


### PR DESCRIPTION
This PR adds a dedicated cut-net config for `kKaHyPar-E` to address https://github.com/kahypar/kahypar/pull/181.