### PR TITLE
Fix compiler warnings

### DIFF
--- a/kahypar/datastructure/graph.h
+++ b/kahypar/datastructure/graph.h
@@ -60,13 +60,15 @@ class Graph {
  private:
   static constexpr bool enable_heavy_assert = false;
 
-  class NodeIDIterator : public std::iterator<
-                           std::forward_iterator_tag,  // iterator_category
-                           NodeID,  // value_type
-                           std::ptrdiff_t,  // difference_type
-                           NodeID*,  // pointer
-                           NodeID>{  // reference
+  class NodeIDIterator {
  public:
+
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = NodeID;
+    using difference_type = std::ptrdiff_t;
+    using pointer = NodeID*;
+    using reference = NodeID;
+
     explicit NodeIDIterator(const NodeID start) :
       _i(start) { }
 

--- a/kahypar/datastructure/hypergraph.h
+++ b/kahypar/datastructure/hypergraph.h
@@ -372,15 +372,16 @@ class GenericHypergraph {
    *
    */
   template <typename ElementType>
-  class HypergraphElementIterator :
-    public std::iterator<std::forward_iterator_tag,    // iterator_category
-                         typename ElementType::IDType,   // value_type
-                         std::ptrdiff_t,   // difference_type
-                         const typename ElementType::IDType*,   // pointer
-                         typename ElementType::IDType>{   // reference
+  class HypergraphElementIterator {
     using IDType = typename ElementType::IDType;
 
  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = typename ElementType::IDType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const typename ElementType::IDType*;
+    using reference = typename ElementType::IDType;
+
     HypergraphElementIterator() = default;
 
     HypergraphElementIterator(const HypergraphElementIterator& other) = default;

--- a/kahypar/io/hypergraph_io.h
+++ b/kahypar/io/hypergraph_io.h
@@ -100,7 +100,7 @@ static inline void readHypergraphFile(const std::string& filename, HypernodeID& 
     index_vector.push_back(edge_vector.size());
     if (line_number_vector != nullptr) {
       line_number_vector->reserve(static_cast<size_t>(num_hyperedges) +
-                                  has_hypernode_weights ? static_cast<size_t>(num_hypernodes) : 0);
+                                  (has_hypernode_weights ? static_cast<size_t>(num_hypernodes) : 0));
       line_number_vector->clear();
     }
 


### PR DESCRIPTION
This PR fixes the following two warnings:

```
 warning: 'iterator<std::forward_iterator_tag, unsigned int, long, const unsigned int *, unsigned int>' is deprecated [-Wdeprecated-declarations]
```

and 

```
 warning: operator '?:' has lower precedence than '+'; '+' will be evaluated first [-Wparentheses]
```