### PR TITLE
fix tests that assume input validation is enabled

### DIFF
--- a/tests/interface/interface_test.cc
+++ b/tests/interface/interface_test.cc
@@ -369,15 +369,17 @@ TEST(KaHyPar, CanCreateHypergraphsViaInterface) {
 }
 
 TEST(KaHyPar, RejectsInvalidHypergraphViaInterface) {
-  kahypar_partition_id_t num_blocks = 2;
-  kahypar_hypernode_id_t num_vertices = 2;
-  kahypar_hyperedge_id_t num_hyperedges = 2;
-  size_t hyperedge_indices[3] = {0, 2, 1}; // invalid index array
-  kahypar_hyperedge_id_t hyperedges[2] = {0, 1};
+  if (VALIDATE_INPUT) {
+    kahypar_partition_id_t num_blocks = 2;
+    kahypar_hypernode_id_t num_vertices = 2;
+    kahypar_hyperedge_id_t num_hyperedges = 2;
+    size_t hyperedge_indices[3] = {0, 2, 1}; // invalid index array
+    kahypar_hyperedge_id_t hyperedges[2] = {0, 1};
 
-  EXPECT_EXIT(kahypar_create_hypergraph(num_blocks, num_vertices, num_hyperedges,
-                                        hyperedge_indices, hyperedges, nullptr, nullptr),
-              ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(kahypar_create_hypergraph(num_blocks, num_vertices, num_hyperedges,
+                                          hyperedge_indices, hyperedges, nullptr, nullptr),
+                ::testing::ExitedWithCode(1), "");
+  }
 }
 
 TEST(KaHyPar, ValidatesInputViaInterface) {
@@ -656,11 +658,13 @@ TEST_F(AHypergraphFileWithHypernodeAndHyperedgeWeights, CanBeParsedIntoKaHyParAH
 }
 
 TEST(CorruptedHypergraphFile, IsRejectedByInputValidation) {
-  kahypar_partition_id_t num_blocks = 2;
-  std::string filename("test_instances/corrupted_hypergraph_with_invalid_pin.hgr");
+  if (VALIDATE_INPUT) {
+    kahypar_partition_id_t num_blocks = 2;
+    std::string filename("test_instances/corrupted_hypergraph_with_invalid_pin.hgr");
 
-  EXPECT_EXIT(kahypar_create_hypergraph_from_file(filename.c_str(), num_blocks),
-              ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(kahypar_create_hypergraph_from_file(filename.c_str(), num_blocks),
+                ::testing::ExitedWithCode(1), "");
+  }
 }
 
 TEST(Seed, CanBeSetViaLibraryInterface) {


### PR DESCRIPTION
Don't execute the tests if input validation is disabled.