### PR TITLE
Export `kahypar_supress_output` function

### DIFF
--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -62,6 +62,7 @@ KAHYPAR_API void kahypar_configure_context_from_file(kahypar_context_t* kahypar_
                                                      const char* ini_file_name);
 
 KAHYPAR_API void kahypar_set_seed(kahypar_context_t* kahypar_context, const int seed);
+KAHYPAR_API void kahypar_supress_output(kahypar_context_t* kahypar_context, const bool decision);
 
 KAHYPAR_API void kahypar_hypergraph_free(kahypar_hypergraph_t* hypergraph);
 

--- a/lib/libkahypar.cc
+++ b/lib/libkahypar.cc
@@ -65,6 +65,10 @@ void kahypar_set_seed(kahypar_context_t* kahypar_context, const int seed) {
   context.partition.seed =seed;
 }
 
+void kahypar_supress_output(kahypar_context_t* kahypar_context, const bool decision) {
+  kahypar::Context& context = *reinterpret_cast<kahypar::Context*>(kahypar_context);
+  context.partition.quiet_mode = decision;
+}
 
 void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                          const char* ini_file_name) {


### PR DESCRIPTION
I was missing the `suppressOutput` feature from the Python API in the C API, so I added it.