### PR TITLE
Extend C interface with metrics and HE connectivity

### DIFF
--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -144,6 +144,19 @@ KAHYPAR_API void kahypar_improve_partition(const kahypar_hypernode_id_t num_vert
                                            kahypar_context_t* kahypar_context,
                                            kahypar_partition_id_t* improved_partition);
 
+KAHYPAR_API kahypar_partition_id_t kahypar_hyperedge_connectivity(const kahypar_hypergraph_t* kahypar_hypergraph, const kahypar_hyperedge_id_t he_id);
+
+KAHYPAR_API kahypar_hyperedge_weight_t kahypar_cut_objective(const kahypar_hypergraph_t* kahypar_hypergraph);
+
+KAHYPAR_API kahypar_hyperedge_weight_t kahypar_soed_objective(const kahypar_hypergraph_t* kahypar_hypergraph);
+
+KAHYPAR_API kahypar_hyperedge_weight_t kahypar_km1_objective(const kahypar_hypergraph_t* kahypar_hypergraph);
+
+KAHYPAR_API double kahypar_absorption_objective(const kahypar_hypergraph_t* kahypar_hypergraph);
+
+KAHYPAR_API double kahypar_imbalance(const kahypar_hypergraph_t* kahypar_hypergraph, const kahypar_context_t* kahypar_context);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libkahypar.cc
+++ b/lib/libkahypar.cc
@@ -24,6 +24,7 @@
 #include "kahypar/io/hypergraph_io.h"
 #include "kahypar-resources/macros.h"
 #include "kahypar/partition/context.h"
+#include "kahypar/partition/metrics.h"
 #include "kahypar/partitioner_facade.h"
 #include "kahypar-resources/utils/randomize.h"
 #include "kahypar/utils/validate.h"
@@ -314,4 +315,36 @@ void kahypar_improve_partition(const kahypar_hypernode_id_t num_vertices,
                     objective,
                     kahypar_context,
                     improved_partition);
+}
+
+
+KAHYPAR_API kahypar_partition_id_t kahypar_hyperedge_connectivity(const kahypar_hypergraph_t* kahypar_hypergraph, const kahypar_hyperedge_id_t he_id) {
+   const kahypar::Hypergraph& hypergraph = *reinterpret_cast<const kahypar::Hypergraph*>(kahypar_hypergraph);
+   return hypergraph.connectivity(he_id);
+}
+
+KAHYPAR_API kahypar_hyperedge_weight_t kahypar_cut_objective(const kahypar_hypergraph_t* kahypar_hypergraph) {
+  const kahypar::Hypergraph& hypergraph = *reinterpret_cast<const kahypar::Hypergraph*>(kahypar_hypergraph);
+  return kahypar::metrics::hyperedgeCut(hypergraph);
+}
+
+KAHYPAR_API kahypar_hyperedge_weight_t kahypar_soed_objective(const kahypar_hypergraph_t* kahypar_hypergraph)  {
+  const kahypar::Hypergraph& hypergraph = *reinterpret_cast<const kahypar::Hypergraph*>(kahypar_hypergraph);
+  return kahypar::metrics::soed(hypergraph);
+}
+
+KAHYPAR_API kahypar_hyperedge_weight_t kahypar_km1_objective(const kahypar_hypergraph_t* kahypar_hypergraph)  {
+  const kahypar::Hypergraph& hypergraph = *reinterpret_cast<const kahypar::Hypergraph*>(kahypar_hypergraph);
+  return kahypar::metrics::km1(hypergraph);
+}
+
+KAHYPAR_API double kahypar_absorption_objective(const kahypar_hypergraph_t* kahypar_hypergraph)  {
+  const kahypar::Hypergraph& hypergraph = *reinterpret_cast<const kahypar::Hypergraph*>(kahypar_hypergraph);
+  return kahypar::metrics::absorption(hypergraph);
+}
+
+KAHYPAR_API double kahypar_imbalance(const kahypar_hypergraph_t* kahypar_hypergraph, const kahypar_context_t* kahypar_context) {
+  const kahypar::Context & context = *reinterpret_cast<const kahypar::Context*>(kahypar_context);
+  const kahypar::Hypergraph& hypergraph = *reinterpret_cast<const kahypar::Hypergraph*>(kahypar_hypergraph);
+  return kahypar::metrics::imbalance(hypergraph, context);
 }


### PR DESCRIPTION
This PR addresses https://github.com/kahypar/kahypar/issues/224 and adds the following functions to the C interface:

```cpp
KAHYPAR_API kahypar_partition_id_t kahypar_hyperedge_connectivity(const kahypar_hypergraph_t* kahypar_hypergraph, const kahypar_hyperedge_id_t he_id);

KAHYPAR_API kahypar_hyperedge_weight_t kahypar_cut_objective(const kahypar_hypergraph_t* kahypar_hypergraph);

KAHYPAR_API kahypar_hyperedge_weight_t kahypar_soed_objective(const kahypar_hypergraph_t* kahypar_hypergraph);

KAHYPAR_API kahypar_hyperedge_weight_t kahypar_km1_objective(const kahypar_hypergraph_t* kahypar_hypergraph);

KAHYPAR_API double kahypar_absorption_objective(const kahypar_hypergraph_t* kahypar_hypergraph);

KAHYPAR_API double kahypar_imbalance(const kahypar_hypergraph_t* kahypar_hypergraph, const kahypar_context_t* kahypar_context);
```

Example code using these new functions:

```cpp
#include <memory>
#include <vector>
#include <iostream>

#include <libkahypar.h>

int main(int argc, char* argv[]) {

  kahypar_context_t* context = kahypar_context_new();
  kahypar_configure_context_from_file(context, "/Users/sebastianschlag/repo/kahypar/config/km1_kKaHyPar_sea20.ini");
  
  kahypar_set_seed(context, 42);

  const kahypar_hypernode_id_t num_vertices = 7;
  const kahypar_hyperedge_id_t num_hyperedges = 4;

  std::unique_ptr<kahypar_hyperedge_weight_t[]> hyperedge_weights = std::make_unique<kahypar_hyperedge_weight_t[]>(4);

  // force the cut to contain hyperedge 0 and 2
  hyperedge_weights[0] = 1;  hyperedge_weights[1] = 1000;
  hyperedge_weights[2] = 1;  hyperedge_weights[3] = 1000;

  std::unique_ptr<size_t[]> hyperedge_indices = std::make_unique<size_t[]>(5);

  hyperedge_indices[0] = 0; hyperedge_indices[1] = 2;
  hyperedge_indices[2] = 6; hyperedge_indices[3] = 9;
  hyperedge_indices[4] = 12;

  std::unique_ptr<kahypar_hyperedge_id_t[]> hyperedges = std::make_unique<kahypar_hyperedge_id_t[]>(12);

  // hypergraph from hMetis manual page 14
  hyperedges[0] = 0;  hyperedges[1] = 2;
  hyperedges[2] = 0;  hyperedges[3] = 1;
  hyperedges[4] = 3;  hyperedges[5] = 4;
  hyperedges[6] = 3;  hyperedges[7] = 4;
  hyperedges[8] = 6;  hyperedges[9] = 2;
  hyperedges[10] = 5; hyperedges[11] = 6;

  const double imbalance = 0.03;
  const kahypar_partition_id_t k = 2;

  kahypar_hyperedge_weight_t objective = 0;

  std::vector<kahypar_partition_id_t> partition(num_vertices, -1);

  kahypar_hypergraph_t * hypergraph =  kahypar_create_hypergraph(k,
                                                num_vertices,
                                                num_hyperedges,
                                                hyperedge_indices.get(), hyperedges.get(),
                                                hyperedge_weights.get(),
                                                nullptr);

  kahypar_partition_hypergraph(hypergraph, k, imbalance, &objective, context, partition.data());


  for(int i = 0; i != num_vertices; ++i) {
    std::cout << i << ":" << partition[i] << std::endl;
  }

  for(int i = 0; i != num_hyperedges; ++i) {
    std::cout << i << ": connectivity=" << kahypar_hyperedge_connectivity(hypergraph, i) << std::endl;
  }

  std::cout << "cut=" << kahypar_cut_objective(hypergraph) << std::endl;
  std::cout << "soed=" << kahypar_soed_objective(hypergraph) << std::endl;
  std::cout << "km1=" << kahypar_km1_objective(hypergraph) << std::endl;
  std::cout << "absorption=" << kahypar_absorption_objective(hypergraph) << std::endl;
  std::cout << "imbalance=" << kahypar_imbalance(hypergraph, context) << std::endl;

  kahypar_context_free(context);
}
```