### PR TITLE
Allow reading from ini file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ profile/*
 external_tools/*
 !external_tools/primes
 .idea*
+.cache
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ if(NOT CMAKE_BUILD_TYPE OR
     message(FATAL_ERROR "CMAKE_BUILD_TYPE not set correctly. Options are: Release|RELEASE, Debug|DEBUG, RelWithDebInfo|RELWITHDEBINFO." )
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+
 # add third-party algorithms to project
 include_directories(external_tools)
 include_directories(external_tools/kahypar-shared-resources)

--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -60,6 +60,8 @@ KAHYPAR_API kahypar_context_t* kahypar_context_new();
 KAHYPAR_API void kahypar_context_free(kahypar_context_t* kahypar_context);
 KAHYPAR_API void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                                      const char* ini_file_name);
+KAHYPAR_API void kahypar_configure_context_from_string(kahypar_context_t* kahypar_context,
+                                                     const char* str);
 
 KAHYPAR_API void kahypar_set_seed(kahypar_context_t* kahypar_context, const int seed);
 KAHYPAR_API void kahypar_supress_output(kahypar_context_t* kahypar_context, const bool decision);

--- a/kahypar/application/command_line_options.h
+++ b/kahypar/application/command_line_options.h
@@ -729,15 +729,8 @@ void processCommandLineInput(Context& context, int argc, char* argv[]) {
   }
 }
 
-
-void parseIniToContext(Context& context, const std::string& ini_filename) {
-  std::ifstream file(ini_filename.c_str());
-  if (!file) {
-    std::cerr << "Could not load context file at: " << ini_filename << std::endl;
-    std::exit(-1);
-  }
-  const int num_columns = 80;
-
+template <typename T>
+void parseIniCommon(Context& context, T& data, int num_columns) {
   po::variables_map cmd_vm;
   po::options_description ini_line_options;
   ini_line_options.add(createGeneralOptionsDescription(context, num_columns))
@@ -748,11 +741,25 @@ void parseIniToContext(Context& context, const std::string& ini_filename) {
   .add(createRefinementOptionsDescription(context, num_columns, false))
   .add(createEvolutionaryOptionsDescription(context, num_columns));
 
-  po::store(po::parse_config_file(file, ini_line_options, true), cmd_vm);
+  po::store(po::parse_config_file(data, ini_line_options, true), cmd_vm);
   po::notify(cmd_vm);
 
   if (context.partition.use_individual_part_weights) {  // Note(Lars): This affects flow network sizes!
     context.partition.epsilon = 0;
   }
+}
+
+inline void parseIniToContext(Context& context, const std::string& ini_filename) {
+  std::ifstream file(ini_filename.c_str());
+  if (!file) {
+    std::cerr << "Could not load context file at: " << ini_filename << std::endl;
+    std::exit(-1);
+  }
+  parseIniCommon(context, file, 80);
+}
+
+inline void parseIniToContextString(Context& context, const std::string& str) {
+  std::istringstream data(str);
+  parseIniCommon(context, data, 80);
 }
 }  // namespace kahypar

--- a/lib/libkahypar.cc
+++ b/lib/libkahypar.cc
@@ -77,6 +77,12 @@ void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                              ini_file_name);
 }
 
+void kahypar_configure_context_from_string(kahypar_context_t* kahypar_context,
+                                         const char* str) {
+  kahypar::parseIniToContextString(*reinterpret_cast<kahypar::Context*>(kahypar_context),
+                             str);
+}
+
 void kahypar_set_fixed_vertices(kahypar_hypergraph_t* kahypar_hypergraph,
                                 const kahypar_partition_id_t* fixed_vertex_blocks) {
   kahypar::Hypergraph& hypergraph = *reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);


### PR DESCRIPTION
As per #228 

Also, adding `comile_commands.json` generation by default. This will make emacs and vim and all your code editors use the json to exactly perfectly parse the files, and give you _way_ better code navigation. Plus of course `.cache` should be in the `.gitignore` along with the compile_commands.json.