### PR TITLE
Also allow static compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ endif()
 include_directories(external_tools)
 include_directories(external_tools/kahypar-shared-resources)
 
+option(BUILD_SHARED_LIBS "Build the shared library" ON)
+option(STATICCOMPILE "Compile to static executable" OFF)
+if (STATICCOMPILE)
+    set(BUILD_SHARED_LIBS OFF)
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
+
 option(KAHYPAR_PYTHON_INTERFACE
   "Enable building the python interface" OFF)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(GNUInstallDirs)
 
-add_library(kahypar SHARED libkahypar.cc)
+add_library(kahypar libkahypar.cc)
 target_link_libraries(kahypar ${Boost_LIBRARIES})
 
 set_target_properties(kahypar PROPERTIES
@@ -27,8 +27,8 @@ configure_file(cmake_uninstall.cmake.in cmake_uninstall.cmake IMMEDIATE @ONLY)
 
 add_custom_target(uninstall-kahypar "${CMAKE_COMMAND}" -P cmake_uninstall.cmake)
 
-add_custom_target(install.library 
-    ${CMAKE_COMMAND} 
-    -DBUILD_TYPE=${CMAKE_BUILD_TYPE} 
-    -P ${CMAKE_BINARY_DIR}/cmake_install.cmake) 
-ADD_DEPENDENCIES(install.library kahypar) 
+add_custom_target(install.library
+    ${CMAKE_COMMAND}
+    -DBUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -P ${CMAKE_BINARY_DIR}/cmake_install.cmake)
+ADD_DEPENDENCIES(install.library kahypar)

--- a/tests/interface/CMakeLists.txt
+++ b/tests/interface/CMakeLists.txt
@@ -1,5 +1,7 @@
 # This test needs test instance files, so we copy them to the corresponding build dir
 file(COPY test_instances DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-add_gmock_test(interface_test interface_test.cc)
-target_link_libraries(interface_test ${Boost_LIBRARIES} kahypar)
+if (NOT STATICCOMPILE)
+    add_gmock_test(interface_test interface_test.cc)
+    target_link_libraries(interface_test ${Boost_LIBRARIES} kahypar)
+endif ()


### PR DESCRIPTION
This allows for static compilation of the library & binary. Perhaps this could be tested on your end. It works for me very well. I need static binaries and libraries, because I want my tools to be super-easily-usable.

As you can see, all my PRs are about usability, not performance. In my opinion, it's best to make tools, especially research tools, usable, so other researchers build on top of them, and you get 100 or thousands of references. If they download the tool and it's hard to use... they may just use another tool.