### PR TITLE
No march/mtune, they can be detrimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,12 +274,11 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pthread -g3")
 
   if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
-    # M1 doesn't seem to support -mtune=native -march=native
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
   else()
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -mtune=native -march=native")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -mtune=native -march=native -g3 ")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
   endif()
 
 if(DEFINED ENV{TRAVIS_ENV})


### PR DESCRIPTION
In general `-march=native` is extremely dangerous -- if you compile it on a newer architecture that has a some weird new new thing, the compiler will use it, and your binary will not run on older machines. It can be a big issue. I'd remove it. I'd also suggest removing `-mtune=native`, as it's hard to guess what the target will use. I know these sound like nitpicks, but especially the `-march=native` is very problematic -- your binaries will either not run, or exit with very weird behaviour (instruction fault), that users will be confused/afraid of.

In my experience, you need none of these to win competitions -- and I have been making tools to do that for 15+ years. You could keep the `-mtune=native` in, but if you run some experiments, I think you will see it doesn't help. The cluster the executable will run on will inevitably be different than where it's compiled.

I'd also question `-O3` -- it often doesn't help at all. In fact it usually makes things slower. I have benchmarked my tools extensively, and it makes my tools slower. Instruction cache is a pain...

Just my 2 cents. 