### PR TITLE
Update get_version to produce valid versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ except ImportError:
 
 def get_version():
     # If on an exact tag (e.g. v1.3.7), use that as the version.
-    # Otherwise fall back to <base>+g<sha> so dev wheels are distinguishable.
+    # Otherwise fall back to <base>.devN using commit count since last tag,
+    # which is PEP 440 compliant and accepted by PyPI.
     base = "1.3.6"
     try:
         tag = (
@@ -33,16 +34,22 @@ def get_version():
     except subprocess.CalledProcessError:
         pass
     try:
-        sha = (
+        desc = (
             subprocess.check_output(
-                ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
+                ["git", "describe", "--tags", "--long"],
+                stderr=subprocess.DEVNULL,
             )
             .decode()
             .strip()
         )
-        return "{}.dev+g{}".format(base, sha)
+        # format: v1.3.5-42-g2e07123 → 42 commits since tag
+        match = re.match(r".*-(\d+)-g[0-9a-f]+$", desc)
+        if match:
+            commit_count = match.group(1)
+            return "{}.dev{}".format(base, commit_count)
     except subprocess.CalledProcessError:
-        return base
+        pass
+    return base
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
@jcmgray's initial approach for versioning produced versions like `1.3.6.dev0+g2e07123`, which got rejected by PyPI with:


> The use of local versions in '1.3.6.dev0+g2e07123' is not allowed. See https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers for more information. 

 Instead of `git rev-parse --short HEAD` producing `1.3.6.dev+g2e07123`, this PR now uses `git describe --tags --long` to get the number of commits since the last tag. With this, the version becomes e.g. `1.3.6.dev42`, which should be a valid PEP 440 dev version that PyPI accepts. The commit count also ensures that newer commits get higher version numbers, so pip can correctly determine which dev build is newer.