### PR TITLE
CI wheel build: Set fetch-depth: 0

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
           persist-credentials: false
 
@@ -61,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
           persist-credentials: false
 


### PR DESCRIPTION
After https://github.com/kahypar/kahypar/pull/243, the wheels build by the CI job are of the form `kahypar-1.3.6-cp310-cp310-macosx_11_0_arm64.whl`, which is missing the local version identifier. 

With this PR, we explicitly set `fetch-depth: 0` so that the `get_version` function should work as expected.